### PR TITLE
Onboarding of light client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,10 +28,6 @@ const Lumino = () => {
       const getLuminoInternalState = () => store.getState();
       luminoConfig = { ...luminoConfig, ...configParams };
       client.defaults.baseURL = luminoConfig.hubEndpoint;
-      client.defaults.headers = {
-        "x-api-key": luminoConfig.apiKey,
-        "Content-type": "application/json",
-      };
       actions = { ...actions };
       luminoFns = {
         actions,

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -4,6 +4,7 @@ import * as depositActions from "./deposit";
 import * as closeActions from "./close";
 import * as paymentActions from "./payment";
 import * as pollingActions from "./polling";
+import * as onboardingActions from "./onboarding";
 
 const Actions = {
   ...openActions,
@@ -12,6 +13,7 @@ const Actions = {
   ...closeActions,
   ...paymentActions,
   ...pollingActions,
+  ...onboardingActions,
 };
 
 export default Actions;

--- a/src/store/actions/index.js
+++ b/src/store/actions/index.js
@@ -3,7 +3,6 @@ import * as getActions from "./get";
 import * as depositActions from "./deposit";
 import * as closeActions from "./close";
 import * as paymentActions from "./payment";
-import * as pollingActions from "./polling";
 import * as onboardingActions from "./onboarding";
 
 const Actions = {
@@ -12,7 +11,6 @@ const Actions = {
   ...getActions,
   ...closeActions,
   ...paymentActions,
-  ...pollingActions,
   ...onboardingActions,
 };
 

--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -1,0 +1,43 @@
+import client from "../../apiRest";
+import resolver from "../../utils/handlerResolver";
+import { STORE_API_KEY } from "../actions/types";
+
+export const onboardingClient = address => async (dispatch, getState, lh) => {
+  try {
+    const urlOnboard = "light_clients/matrix/credentials";
+    const onboardReq = await client.get(urlOnboard, { params: { address } });
+    // We get the data
+    const {
+      display_name_to_sign,
+      seed_retry,
+      password_to_sign,
+    } = onboardReq.data;
+    // Sign it
+    const signed_display_name = await resolver(display_name_to_sign, lh, true);
+    const signed_password = await resolver(password_to_sign, lh, true);
+    const signed_seed_retry = await resolver(seed_retry, lh, true);
+    // Prepare a body for the request with all the required data
+    const body = {
+      address,
+      signed_password,
+      signed_display_name,
+      signed_seed_retry,
+      password: password_to_sign,
+      display_name: display_name_to_sign,
+      seed_retry,
+    };
+    const urlPostOnboard = "light_clients/";
+    const resOnboard = await client.post(urlPostOnboard, body);
+    // We extract the api key, set it as a header and store it on redux
+    const { api_key } = resOnboard.data;
+    client.defaults.headers = { "x-api-key": api_key };
+    dispatch({ type: STORE_API_KEY, apiKey: api_key });
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const getApiKey = () => (dispatch, getState) => getState().client.apiKey;
+
+export const setApiKey = apiKey => dispatch =>
+  dispatch({ type: STORE_API_KEY, apiKey });

--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -32,6 +32,8 @@ export const onboardingClient = address => async (dispatch, getState, lh) => {
     const { api_key } = resOnboard.data;
     client.defaults.headers = { "x-api-key": api_key };
     dispatch({ type: STORE_API_KEY, apiKey: api_key });
+    const allData = getState();
+    lh.storage.saveLuminoData(allData);
   } catch (error) {
     throw error;
   }
@@ -39,5 +41,15 @@ export const onboardingClient = address => async (dispatch, getState, lh) => {
 
 export const getApiKey = () => (dispatch, getState) => getState().client.apiKey;
 
-export const setApiKey = apiKey => dispatch =>
-  dispatch({ type: STORE_API_KEY, apiKey });
+export const setApiKey = apiKey => (dispatch, getState, lh) => {
+  dispatch({
+    type: STORE_API_KEY,
+    apiKey,
+  });
+  client.defaults.headers = {
+    "x-api-key": apiKey,
+  };
+
+  const allData = getState();
+  lh.storage.saveLuminoData(allData);
+};

--- a/src/store/actions/types.js
+++ b/src/store/actions/types.js
@@ -23,3 +23,7 @@ export const MESSAGE_POLLING_STOP = "MESSAGE_POLLING_STOP";
 export const MESSAGE_POLLING_ERROR = "MESSAGE_POLLING_ERROR";
 export const MESSAGE_POLLING = "MESSAGE_POLLING";
 export const MESSAGE_SENT = "MESSAGE_SENT";
+
+// Oboarding Actions
+
+export const STORE_API_KEY = "STORE_API_KEY";

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -19,13 +19,17 @@ let storage = defaultStorage;
 
 const observableMiddleware = createEpicMiddleware();
 
+const setApiKeyFromStore = store => {
+  // We set the api key if teh redux store has one, if not, we fallback to the one from the developer
+  const api_key = store.getState().client.apiKey;
+  if (api_key) client.defaults.headers = { "x-api-key": api_key };
+};
+
 const initStore = async (storageImpl, luminoHandler) => {
   if (storageImpl) storage = storageImpl;
   const dataFromStorage = await storage.getLuminoData();
   let data = {};
-  if (dataFromStorage) {
-    data = dataFromStorage;
-  }
+  if (dataFromStorage) data = dataFromStorage;
   const lh = {
     sign: luminoHandler.sign,
     offChainSign: luminoHandler.offChainSign,
@@ -43,6 +47,7 @@ const initStore = async (storageImpl, luminoHandler) => {
       )
     )
   );
+  setApiKeyFromStore(store);
   observableMiddleware.run(paymentsMonitoredEpic);
   sagaMiddleware.run(rootSaga);
   store.dispatch({ type: MESSAGE_POLLING_START });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ import rootReducer from "./reducers";
 import { paymentsMonitoredEpic } from "./epics";
 import rootSaga from "./sagas";
 import { MESSAGE_POLLING_START } from "./actions/types";
+import client from "../apiRest";
 
 let store = null;
 const defaultStore = { channelReducer: [] };

--- a/src/store/reducers/clientReducer.js
+++ b/src/store/reducers/clientReducer.js
@@ -1,0 +1,18 @@
+import { STORE_API_KEY } from "../actions/types";
+
+const initialState = {
+  apiKey: "",
+  address: "",
+};
+
+const clientReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case STORE_API_KEY:
+      const newApiKey = { ...state, apiKey: action.apiKey };
+      return newApiKey;
+    default:
+      return state;
+  }
+};
+
+export default clientReducer;

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -3,12 +3,14 @@ import channel from "./channelReducer";
 import paymentIds from "./paymentIdsReducer";
 import channelStates from "./channelStatesReducer";
 import payments from "./paymentsReducer";
+import clientReducer from "./clientReducer";
 
 const rootReducer = combineReducers({
   channelReducer: channel,
   paymentIds,
   channelStates,
-  payments
+  payments,
+  client: clientReducer,
 });
 
 export default rootReducer;

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -3,6 +3,7 @@ import {
   getPendingPaymentById,
   paymentExistsInAnyState,
   getChannelById,
+  getPaymentIds,
 } from "../store/functions";
 import Store from "../store";
 import {
@@ -46,7 +47,11 @@ export const messageManager = messages => {
 
       // We can't handle payments that don't exist, but we can handle reception of a new one
       if (!payment && type !== MessageType.LOCKED_TRANSFER) return null;
-
+      // We have to check if a locked transfer may be from a payment that has been processed already
+      if (type === MessageType.LOCKED_TRANSFER) {
+        const hasPaymentInPendingOrComplete = getPaymentIds()[paymentId];
+        if (hasPaymentInPendingOrComplete) return null;
+      }
       if (is_signed && type !== MessageType.LOCKED_TRANSFER) {
         const signatureAddress = signatureRecover(msg[messageSignedKey]);
         const { initiator, partner } = payment;


### PR DESCRIPTION
This PR includes the feature for the onboarding of a LC in the SDK.

With this, the a new method has been added to the SDK, which allows it to handle automatically the onboarding of a LC.

The SDK will invoke the hub, get the parameters, sign, send them back, retrieve and store the api key from it.
The SDK will make the api key the default when lumino is initialized.
Also there are methods for overriding the apiKey and retrieve it, in case of need for storage in another environment or testing.