### PR TITLE
Multi token support and QoL changes

### DIFF
--- a/src/scripts/close.js
+++ b/src/scripts/close.js
@@ -1,6 +1,10 @@
 import { tokenNetworkAbi } from "./constants";
 import Web3 from "web3";
 import Lumino from "../Lumino/index";
+import {
+  DEFAULT_GAS_PRICE,
+  DEFAULT_GAS_LIMIT,
+} from "../config/channelParamsConstants";
 
 const balance_hash =
   "0x00000000000000000000000000000000000000000000000000000000000000";
@@ -22,8 +26,8 @@ export const createCloseTx = async params => {
     const txCount = await web3.eth.getTransactionCount(params.address);
     const close = {
       nonce: web3.utils.toHex(txCount),
-      gasPrice: params.gasPrice,
-      gasLimit: params.gasLimit,
+      gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
+      gasLimit: params.gasLimit || DEFAULT_GAS_LIMIT,
       to: params.tokenNetworkAddress,
       value: "0x00",
       data: tokenNetwork.methods

--- a/src/scripts/deposit.js
+++ b/src/scripts/deposit.js
@@ -1,6 +1,10 @@
 import { tokenAbi, tokenNetworkAbi } from "./constants";
 import Web3 from "web3";
 import Lumino from "../Lumino/index";
+import {
+  DEFAULT_GAS_PRICE,
+  DEFAULT_GAS_LIMIT,
+} from "../config/channelParamsConstants";
 
 export const createApprovalTx = async params => {
   try {
@@ -10,8 +14,8 @@ export const createApprovalTx = async params => {
     const token = new web3.eth.Contract(tokenAbi, params.tokenAddress);
     const approval = {
       nonce: web3.utils.toHex(txCount),
-      gasPrice: params.gasPrice,
-      gasLimit: params.gasLimitApproval,
+      gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
+      gasLimit: params.gasLimitApproval || DEFAULT_GAS_LIMIT,
       to: params.tokenAddress,
       value: "0x00",
       data: token.methods
@@ -37,8 +41,8 @@ export const createDepositTx = async params => {
     const txCount = await web3.eth.getTransactionCount(params.address);
     const deposit = {
       nonce: web3.utils.toHex(txCount + 1),
-      gasPrice: params.gasPrice,
-      gasLimit: params.gasLimitDeposit,
+      gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
+      gasLimit: params.gasLimitDeposit || DEFAULT_GAS_LIMIT,
       to: params.tokenNetworkAddress,
       value: "0x00",
       data: tokenNetwork.methods

--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -31,10 +31,12 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
     const resOnboard = await client.post(urlPostOnboard, body);
     // We extract the api key, set it as a header and store it on redux
     const { api_key } = resOnboard.data;
-    client.defaults.headers = { "x-api-key": api_key };
-    dispatch({ type: STORE_API_KEY, apiKey: api_key });
-    const allData = getState();
-    lh.storage.saveLuminoData(allData);
+    if (api_key) {
+      client.defaults.headers = { "x-api-key": api_key };
+      dispatch({ type: STORE_API_KEY, apiKey: api_key });
+      const allData = getState();
+      lh.storage.saveLuminoData(allData);
+    }
   } catch (error) {
     throw error;
   }

--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -5,6 +5,7 @@ import {
   MESSAGE_POLLING_START,
   MESSAGE_POLLING_STOP,
   SET_PAYMENT_SECRET,
+  UPDATE_NON_CLOSING_BP,
 } from "./types";
 import client from "../../apiRest";
 import resolver from "../../utils/handlerResolver";
@@ -16,6 +17,7 @@ import {
   getDataToSignForBalanceProof,
   getDataToSignForProcessed,
   getDataToSignForSecretRequest,
+  getDataToSignForNonClosingBalanceProof,
 } from "../../utils/pack";
 import { validateLockedTransfer } from "../../utils/validators";
 import { getChannelsState } from "../functions";
@@ -363,6 +365,47 @@ export const putBalanceProof = (message, payment) => async (
   } catch (reqEx) {
     console.error("reqEx Put SecretReveal", reqEx);
   }
+};
+
+export const putNonClosingBalanceProof = (message, payment) => async (
+  dispatch,
+  getState,
+  lh
+) => {
+  const { getAddress } = ethers.utils;
+  const dataToSign = getDataToSignForNonClosingBalanceProof(message);
+  let signature = "";
+  try {
+    signature = await resolver(dataToSign, lh, true);
+  } catch (resolverError) {
+    throw resolverError;
+  }
+  const body = {
+    sender: getAddress(payment.partner),
+    light_client_payment_id: payment.paymentId,
+    secret_hash: payment.secret_hash,
+    nonce: message.nonce,
+    channel_id: payment.channelId,
+    token_network_address: payment.tokenNetworkAddress,
+    lc_bp_signature: signature,
+    partner_balance_proof: message,
+  };
+  console.log(body);
+  debugger;
+  // try {
+  //   const urlPut = "watchtower";
+  //   await client.put(urlPut, body, {
+  //     transformResponse: res => JSONbig.parse(res),
+  //   });
+  // dispatch({
+  //   type: UPDATE_NON_CLOSING_BP,
+  //   channelId: payment.channelId,
+  //   nonClosingBp: body,
+  // });
+  //   dispatch(saveLuminoData());
+  // } catch (reqEx) {
+  //   console.error("reqEx Put SecretReveal", reqEx);
+  // }
 };
 
 export const setPaymentSecret = (paymentId, secret) => ({

--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -390,22 +390,20 @@ export const putNonClosingBalanceProof = (message, payment) => async (
     lc_bp_signature: signature,
     partner_balance_proof: message,
   };
-  console.log(body);
-  debugger;
-  // try {
-  //   const urlPut = "watchtower";
-  //   await client.put(urlPut, body, {
-  //     transformResponse: res => JSONbig.parse(res),
-  //   });
-  // dispatch({
-  //   type: UPDATE_NON_CLOSING_BP,
-  //   channelId: payment.channelId,
-  //   nonClosingBp: body,
-  // });
-  //   dispatch(saveLuminoData());
-  // } catch (reqEx) {
-  //   console.error("reqEx Put SecretReveal", reqEx);
-  // }
+  try {
+    const urlPut = "watchtower";
+    await client.put(urlPut, body, {
+      transformResponse: res => JSONbig.parse(res),
+    });
+    dispatch({
+      type: UPDATE_NON_CLOSING_BP,
+      channelId: payment.channelId,
+      nonClosingBp: body,
+    });
+    dispatch(saveLuminoData());
+  } catch (reqEx) {
+    console.error("reqEx Put SecretReveal", reqEx);
+  }
 };
 
 export const setPaymentSecret = (paymentId, secret) => ({

--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -95,6 +95,7 @@ export const createPayment = params => async (dispatch, getState, lh) => {
         amount: message.lock.amount,
         secret_hash: secrethash,
         channelId: dataToPut.message.channel_identifier,
+        token: token_address,
         tokenNetworkAddress: dataToPut.message.token_network_address,
         chainId: dataToPut.message.chain_id,
       },
@@ -144,7 +145,6 @@ const getRandomBN = () => {
   const randomBN = BigNumber.random(18).toString();
   return new BigNumber(randomBN.split(".")[1]).toString();
 };
-// TODO: Try to make sure that the recipient and sender are always correct in reception
 export const putDelivered = (
   message,
   payment,
@@ -386,7 +386,7 @@ export const putNonClosingBalanceProof = (message, payment) => async (
     secret_hash: payment.secret_hash,
     nonce: message.nonce,
     channel_id: payment.channelId,
-    token_network_address: payment.tokenNetworkAddress,
+    token_network_address: getAddress(payment.tokenNetworkAddress),
     lc_bp_signature: signature,
     partner_balance_proof: message,
   };
@@ -398,6 +398,7 @@ export const putNonClosingBalanceProof = (message, payment) => async (
     dispatch({
       type: UPDATE_NON_CLOSING_BP,
       channelId: payment.channelId,
+      token: getAddress(payment.token),
       nonClosingBp: body,
     });
     dispatch(saveLuminoData());

--- a/src/store/actions/types.js
+++ b/src/store/actions/types.js
@@ -18,6 +18,7 @@ export const SET_PAYMENT_SECRET = "SET_PAYMENT_SECRET";
 export const SET_PAYMENT_COMPLETE = "SET_PAYMENT_COMPLETE";
 export const RECEIVED_PAYMENT = "RECEIVED_PAYMENT";
 export const SET_SECRET_MESSAGE_ID = "SET_SECRET_MESSAGE_ID";
+export const UPDATE_NON_CLOSING_BP = "UPDATE_NON_CLOSING_BP";
 
 // Polling actions
 
@@ -28,8 +29,7 @@ export const MESSAGE_POLLING = "MESSAGE_POLLING";
 export const MESSAGE_SENT = "MESSAGE_SENT";
 export const CHANGE_PAYMENT_POLLING_TIME = "CHANGE_PAYMENT_POLLING_TIME";
 
-// Oboarding Actions
+// Onboarding Actions
 
 export const STORE_API_KEY = "STORE_API_KEY";
-
 export const SET_CLIENT_ADDRESS = "SET_CLIENT_ADDRESS";

--- a/src/store/functions/channels.js
+++ b/src/store/functions/channels.js
@@ -6,8 +6,8 @@ export const getChannelsState = () => {
   return channelStates;
 };
 
-export const getChannelById = id => {
+export const getChannelByIdAndToken = (id, token) => {
   const store = Store.getStore();
   const { channelReducer: channels } = store.getState();
-  return channels[id];
+  return channels[`${id}-${token}`];
 };

--- a/src/store/functions/index.js
+++ b/src/store/functions/index.js
@@ -5,4 +5,4 @@ export {
   paymentExistsInAnyState,
   paymentHasMessageOrder,
 } from "./payments";
-export { getChannelById, getChannelsState } from "./channels";
+export { getChannelByIdAndToken, getChannelsState } from "./channels";

--- a/src/store/reducers/channelReducer.js
+++ b/src/store/reducers/channelReducer.js
@@ -3,6 +3,7 @@ import {
   NEW_DEPOSIT,
   SET_CHANNEL_CLOSED,
   CHANGE_CHANNEL_BALANCE,
+  UPDATE_NON_CLOSING_BP,
 } from "../actions/types";
 import { ethers } from "ethers";
 
@@ -74,6 +75,15 @@ const channel = (state = initialState, action) => {
             .toString(),
           receivedTokens: channelReceived.toString(),
           sentTokens: channelSent.toString(),
+        },
+      };
+    case UPDATE_NON_CLOSING_BP:
+      const chBp = action.channelId;
+      return {
+        ...state,
+        [chBp]: {
+          ...state[chBp],
+          nonClosingBp: action.nonClosingBp,
         },
       };
     default:

--- a/src/store/reducers/channelStatesReducer.js
+++ b/src/store/reducers/channelStatesReducer.js
@@ -6,7 +6,10 @@ const initialState = {};
 const channel = (state = initialState, action) => {
   switch (action.type) {
     case OPEN_CHANNEL:
-      const newChannels = { ...state, [action.channelId]: CHANNEL_OPENED };
+      const nChannelId = action.channel.channel_identifier;
+      const nTokenAdd = action.channel.token_address;
+      const nChannel = `${nChannelId}-${nTokenAdd}`;
+      const newChannels = { ...state, [nChannel]: CHANNEL_OPENED };
       return newChannels;
     default:
       return state;

--- a/src/store/sagas/index.js
+++ b/src/store/sagas/index.js
@@ -53,19 +53,19 @@ export function* workMessagePolling({ data }) {
       if (Object.keys(p.messages).length === 14) completed.push(p.paymentId);
     });
     yield all(completed.map(paymentId => setCompleted(paymentId)));
-    const pendingAfterCompletion = yield select(getPendingPayments);
-    const actualPaymentPollingTime = yield select(getPaymentPollingTime);
-    if (!Object.keys(pendingAfterCompletion).length) {
-      if (actualPaymentPollingTime !== 10000) {
-        yield put(setPaymentPollingTimerTo(10000));
-        yield restartPolling();
-      }
-    } else {
-      if (actualPaymentPollingTime !== 2000) {
-        yield put(setPaymentPollingTimerTo(2000));
-        yield restartPolling();
-      }
-    }
+    // const pendingAfterCompletion = yield select(getPendingPayments);
+    // const actualPaymentPollingTime = yield select(getPaymentPollingTime);
+    // if (!Object.keys(pendingAfterCompletion).length) {
+    //   if (actualPaymentPollingTime !== 10000) {
+    //     yield put(setPaymentPollingTimerTo(10000));
+    //     yield restartPolling();
+    //   }
+    // } else {
+    //   if (actualPaymentPollingTime !== 2000) {
+    //     yield put(setPaymentPollingTimerTo(2000));
+    //     yield restartPolling();
+    //   }
+    // }
     yield put(saveLuminoData());
   } catch (error) {
     console.error(error);

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -2,7 +2,7 @@ import { MessageType, MessageKeyForOrder } from "../config/messagesConstants";
 import {
   getPendingPaymentById,
   paymentExistsInAnyState,
-  getChannelById,
+  getChannelByIdAndToken,
   getPaymentIds,
 } from "../store/functions";
 import Store from "../store";
@@ -100,7 +100,10 @@ const manageLockedTransfer = (message, payment, messageSignedKey) => {
     return null;
   if (paymentExistsInAnyState(msg.message_identifier)) return null;
   // If all ok validate the rest of params
-  const channel = getChannelById(msg.channel_identifier);
+  const channel = getChannelByIdAndToken(
+    msg.channel_identifier,
+    getAddress(msg.token)
+  );
   validateReceptionLT(msg, channel);
   const store = Store.getStore();
   // This function add the message to the store in its proper order
@@ -127,9 +130,11 @@ const manageLockedTransfer = (message, payment, messageSignedKey) => {
       channelId: msg.channel_identifier,
       tokenNetworkAddress: msg.token_network_address,
       chainId: msg.chain_id,
+      token: getAddress(msg.token),
     },
     paymentId: `${msg.payment_identifier}`,
     channelId: msg.channel_identifier,
+    token: getAddress(msg.token),
   };
   store.dispatch(actionObj);
   store.dispatch({ type: RECEIVED_PAYMENT, payment: actionObj });

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -14,6 +14,7 @@ import {
   putProcessed,
   putSecretRequest,
   setPaymentSecret,
+  putNonClosingBalanceProof,
 } from "../store/actions/payment";
 import { saveLuminoData } from "../store/actions/storage";
 import {
@@ -320,6 +321,7 @@ const manageSecret = (msg, payment, messageSignedKey) => {
   // Put BP for sent payments
   if (!payment.isReceived)
     return store.dispatch(putBalanceProof(msg[messageSignedKey], payment));
+  store.dispatch(putNonClosingBalanceProof(msg[messageSignedKey], payment));
   store.dispatch(putDelivered(msg[messageSignedKey], payment, 12, true));
   return store.dispatch(putProcessed(msg[messageSignedKey], payment, 13));
 };

--- a/src/utils/pack.js
+++ b/src/utils/pack.js
@@ -108,9 +108,12 @@ export const getDataToSignForProcessed = message => {
 };
 
 // INFO: This is also used for secret, the BP is a response a to a "Secret" message
-export const getDataToSignForBalanceProof = message => {
+export const getDataToSignForBalanceProof = (
+  message,
+  type = MessageType.BALANCE_PROOF
+) => {
   const messageHashUnhashed = ethers.utils.concat([
-    hexEncode(MessageNumPad[MessageType.BALANCE_PROOF], 1),
+    hexEncode(MessageNumPad[MessageType.BALANCE_PROOF], 1), // Always 4
     hexEncode(0, 3),
     hexEncode(message.chain_id, 32),
     hexEncode(message.message_identifier, 8, true),
@@ -132,15 +135,23 @@ export const getDataToSignForBalanceProof = message => {
     message.locksroot
   );
 
+  const BPType = type === MessageType.BALANCE_PROOF ? 1 : 2;
+
   const dataToSign = ethers.utils.concat([
     hexEncode(message.token_network_address, 20),
     hexEncode(message.chain_id, 32),
-    hexEncode(1, 32), // Balance Proof
+    hexEncode(BPType, 32), // Balance Proof or Update Balance Proof
     hexEncode(message.channel_identifier, 32),
     hexEncode(balanceHash, 32), // balance hash
     hexEncode(message.nonce, 32),
     hexEncode(messageHash, 32), // additional hash
   ]);
+  return dataToSign;
+};
+
+export const getDataToSignForNonClosingBalanceProof = message => {
+  const bpData = getDataToSignForBalanceProof(message, "UPDATE_BALANCE_PROOF");
+  const dataToSign = ethers.utils.concat([bpData, message.signature]);
   return dataToSign;
 };
 

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -44,8 +44,10 @@ export const validateLockedTransfer = (message, requestBody, channels = {}) => {
   const hasSameTokenAddress =
     getAddress(message.token) === requestBody.token_address;
   if (!hasSameTokenAddress) throwGenericLockedTransfer("Token Address");
-  const hasChannelAndIsOpened =
-    channels[message.channel_identifier] === CHANNEL_OPENED;
+  const channelId = `${message.channel_identifier}-${getAddress(
+    message.token
+  )}`;
+  const hasChannelAndIsOpened = channels[channelId] === CHANNEL_OPENED;
   if (!hasChannelAndIsOpened)
     throwChannelNotFoundOrNotOpened(message.partner_address);
 };


### PR DESCRIPTION
PR includes #24 so please merge it before this one.

The SDK didn't have multi-token support, we always assumed that channels were unique.
Now we store channels as a key composed of channelId-TokenAddress.

Most of the logic is the same as before, but this comes at a price, previous channels are now incompatible with this format, so this PR is a breaking change.

Now thanks to this the SDK can manage multiple tokens and multiple channels across them, with their balances not being overwritten.

EDIT: 
I've just added to the PR a change to the gasPrice and gasLimit, now for all operations we use the gp and gl passed by the user OR we use the one that we have for default in the config (gasPrice 0.1 gwei and limit 200k wei)
Also there is now an if clause on onboarding, to prevent the sdk for setting invalid api_keys if the service were to fail