### PR TITLE
Fix Open Channel Token Request

### DIFF
--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -4,6 +4,7 @@ import client from "../../apiRest";
 import resolver from "../../utils/handlerResolver";
 import { createOpenTx } from "../../scripts/open";
 import { getTokenNetworkByTokenAddress } from "../functions/tokens";
+import { requestTokenNetworkFromTokenAddress } from "./tokens";
 
 /**
  * Open a channel.
@@ -19,8 +20,9 @@ export const openChannel = params => async (dispatch, getState, lh) => {
     const clientAddress = getState().client.address;
     let tokenNetwork = getTokenNetworkByTokenAddress(tokenAddress);
     if (!tokenNetwork) {
-      await getTokenNetworkByTokenAddress(tokenAddress);
-      tokenNetwork = getTokenNetworkByTokenAddress(tokenAddress);
+      tokenNetwork = await dispatch(
+        requestTokenNetworkFromTokenAddress(tokenAddress)
+      );
     }
 
     const txParams = {

--- a/src/store/actions/tokens.js
+++ b/src/store/actions/tokens.js
@@ -17,6 +17,7 @@ export const requestTokenNetworkFromTokenAddress = tokenAddress => async dispatc
     const url = `tokens/${tokenAddress}`;
     const res = await client.get(url);
     dispatch({ type: ADD_NEW_TOKEN, tokenNetwork: res.data, tokenAddress });
+    return res.data;
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
This PR has a fix for the openChannel method.

When we tried to store tokens in our storage for future use (in order not to query the HUB all the time whenever we needed one), we stored them and asked the storage for them.

But in this process a bug was introduced and the request was never made, in case that the token wasn't in the storage, all the open channel process would fail due to the request never firing.

With these changes, the open channel method works again.