### PR TITLE
Store token name and symbol on channel

### DIFF
--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -3,7 +3,10 @@ import { CHANNEL_OPENED } from "../../config/channelStates";
 import client from "../../apiRest";
 import resolver from "../../utils/handlerResolver";
 import { createOpenTx } from "../../scripts/open";
-import { getTokenNetworkByTokenAddress } from "../functions/tokens";
+import {
+  getTokenNetworkByTokenAddress,
+  requestTokenNameAndSymbol,
+} from "../functions/tokens";
 import { requestTokenNetworkFromTokenAddress } from "./tokens";
 
 /**
@@ -42,11 +45,19 @@ export const openChannel = params => async (dispatch, getState, lh) => {
       };
 
       const res = await client.put("light_channels", { ...requestBody });
+
+      const {
+        name: token_name,
+        symbol: token_symbol,
+      } = await requestTokenNameAndSymbol(tokenAddress);
+
       dispatch({
         type: OPEN_CHANNEL,
         channelId: res.data.channel_identifier,
         channel: {
           ...res.data,
+          token_symbol,
+          token_name,
           sdk_status: CHANNEL_OPENED,
         },
       });

--- a/src/store/functions/tokens.js
+++ b/src/store/functions/tokens.js
@@ -1,5 +1,8 @@
 import Store from "../index";
 import { swapObjValueForKey } from "../../utils/functions";
+import Lumino from "../../Lumino";
+import Web3 from "web3";
+import { tokenAbi } from "../../scripts/constants";
 
 /**
  * Returns the Token Networks and their corresponding Token Address
@@ -29,4 +32,18 @@ export const getTokenAddressByTokenNetwork = tokenNetwork => {
 export const getTokenNetworkByTokenAddress = tokenAddress => {
   const tokenAddresses = getKnownTokenAddresses();
   return tokenAddresses[tokenAddress] || null;
+};
+
+export const requestTokenNameAndSymbol = async tokenAddress => {
+  try {
+    const { rskEndpoint } = Lumino.getConfig();
+    const web3 = new Web3(rskEndpoint);
+    const token = new web3.eth.Contract(tokenAbi, tokenAddress);
+    const name = await token.methods.name().call();
+    const symbol = await token.methods.symbol().call();
+
+    return { name, symbol };
+  } catch (error) {
+    console.log(error);
+  }
 };

--- a/src/store/sagas/index.js
+++ b/src/store/sagas/index.js
@@ -47,10 +47,6 @@ function* restartPolling() {
   yield put(startPaymentPolling());
 }
 
-function* localDispatch(data) {
-  yield put(data);
-}
-
 function* setCompleted(paymentId) {
   return yield put({ type: SET_PAYMENT_COMPLETE, paymentId });
 }


### PR DESCRIPTION
This PR adds a function to the SDK that allows the openChannel script to get and store the token name and symbol.

This is a enhancement that improves the experience of the user, so now they can display the name of the token without any problem.

This PR also deletes some dead and not used code in the saga workers.