### PR TITLE
Close channel with balance

### DIFF
--- a/src/scripts/close.js
+++ b/src/scripts/close.js
@@ -15,36 +15,32 @@ const signature =
   "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
 export const createCloseTx = async params => {
-  try {
-    const { rskEndpoint, chainId } = Lumino.getConfig();
-    const web3 = new Web3(rskEndpoint);
-    const tokenNetwork = new web3.eth.Contract(
-      tokenNetworkAbi,
-      params.tokenNetworkAddress
-    );
+  const { rskEndpoint, chainId } = Lumino.getConfig();
+  const web3 = new Web3(rskEndpoint);
+  const tokenNetwork = new web3.eth.Contract(
+    tokenNetworkAbi,
+    params.tokenNetworkAddress
+  );
 
-    const txCount = await web3.eth.getTransactionCount(params.address);
-    const close = {
-      nonce: web3.utils.toHex(txCount),
-      gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
-      gasLimit: params.gasLimit || DEFAULT_GAS_LIMIT,
-      to: params.tokenNetworkAddress,
-      value: "0x00",
-      data: tokenNetwork.methods
-        .closeChannel(
-          params.channel_identifier,
-          params.partner,
-          balance_hash,
-          nonce,
-          additional_hash,
-          signature
-        )
-        .encodeABI(),
-      chainId,
-    };
+  const txCount = await web3.eth.getTransactionCount(params.address);
+  const close = {
+    nonce: web3.utils.toHex(txCount),
+    gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
+    gasLimit: params.gasLimit || DEFAULT_GAS_LIMIT,
+    to: params.tokenNetworkAddress,
+    value: "0x00",
+    data: tokenNetwork.methods
+      .closeChannel(
+        params.channel_identifier,
+        params.partner,
+        balance_hash,
+        nonce,
+        additional_hash,
+        signature
+      )
+      .encodeABI(),
+    chainId,
+  };
 
-    return close;
-  } catch (e) {
-    throw e;
-  }
+  return close;
 };

--- a/src/scripts/close.js
+++ b/src/scripts/close.js
@@ -31,7 +31,7 @@ export const createCloseTx = async params => {
     value: "0x00",
     data: tokenNetwork.methods
       .closeChannel(
-        params.channel_identifier,
+        params.channelIdentifier,
         params.partner,
         balance_hash,
         nonce,

--- a/src/scripts/deposit.js
+++ b/src/scripts/deposit.js
@@ -7,57 +7,49 @@ import {
 } from "../config/channelParamsConstants";
 
 export const createApprovalTx = async params => {
-  try {
-    const { rskEndpoint, chainId } = Lumino.getConfig();
-    const web3 = new Web3(rskEndpoint);
-    const txCount = await web3.eth.getTransactionCount(params.address);
-    const token = new web3.eth.Contract(tokenAbi, params.tokenAddress);
-    const approval = {
-      nonce: web3.utils.toHex(txCount),
-      gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
-      gasLimit: params.gasLimitApproval || DEFAULT_GAS_LIMIT,
-      to: params.tokenAddress,
-      value: "0x00",
-      data: token.methods
-        .approve(params.tokenNetworkAddress, params.amount)
-        .encodeABI(),
-      chainId,
-    };
+  const { rskEndpoint, chainId } = Lumino.getConfig();
+  const web3 = new Web3(rskEndpoint);
+  const txCount = await web3.eth.getTransactionCount(params.address);
+  const token = new web3.eth.Contract(tokenAbi, params.tokenAddress);
+  const approval = {
+    nonce: web3.utils.toHex(txCount),
+    gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
+    gasLimit: params.gasLimitApproval || DEFAULT_GAS_LIMIT,
+    to: params.tokenAddress,
+    value: "0x00",
+    data: token.methods
+      .approve(params.tokenNetworkAddress, params.amount)
+      .encodeABI(),
+    chainId,
+  };
 
-    return approval;
-  } catch (e) {
-    throw e;
-  }
+  return approval;
 };
 
 export const createDepositTx = async params => {
-  try {
-    const { rskEndpoint, chainId } = Lumino.getConfig();
-    const web3 = new Web3(rskEndpoint);
-    const tokenNetwork = new web3.eth.Contract(
-      tokenNetworkAbi,
-      params.tokenNetworkAddress
-    );
-    const txCount = await web3.eth.getTransactionCount(params.address);
-    const deposit = {
-      nonce: web3.utils.toHex(txCount + 1),
-      gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
-      gasLimit: params.gasLimitDeposit || DEFAULT_GAS_LIMIT,
-      to: params.tokenNetworkAddress,
-      value: "0x00",
-      data: tokenNetwork.methods
-        .setTotalDeposit(
-          params.channelId,
-          params.address,
-          params.amount,
-          params.partner
-        )
-        .encodeABI(),
-      chainId,
-    };
+  const { rskEndpoint, chainId } = Lumino.getConfig();
+  const web3 = new Web3(rskEndpoint);
+  const tokenNetwork = new web3.eth.Contract(
+    tokenNetworkAbi,
+    params.tokenNetworkAddress
+  );
+  const txCount = await web3.eth.getTransactionCount(params.address);
+  const deposit = {
+    nonce: web3.utils.toHex(txCount + 1),
+    gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
+    gasLimit: params.gasLimitDeposit || DEFAULT_GAS_LIMIT,
+    to: params.tokenNetworkAddress,
+    value: "0x00",
+    data: tokenNetwork.methods
+      .setTotalDeposit(
+        params.channelId,
+        params.address,
+        params.amount,
+        params.partner
+      )
+      .encodeABI(),
+    chainId,
+  };
 
-    return deposit;
-  } catch (e) {
-    throw e;
-  }
+  return deposit;
 };

--- a/src/scripts/open.js
+++ b/src/scripts/open.js
@@ -1,30 +1,34 @@
 import { tokenNetworkAbi } from "./constants";
-import { DEFAULT_SETTLE_TIMEOUT, DEFAULT_GAS_LIMIT, DEFAULT_GAS_PRICE } from '../config/channelParamsConstants'
+import {
+  DEFAULT_SETTLE_TIMEOUT,
+  DEFAULT_GAS_LIMIT,
+  DEFAULT_GAS_PRICE,
+} from "../config/channelParamsConstants";
 import Web3 from "web3";
 import Lumino from "../Lumino/index";
 
 export const createOpenTx = async params => {
-  try {
-    const { rskEndpoint, chainId } = Lumino.getConfig();
-    const web3 = new Web3(rskEndpoint);
-    const tokenNetwork = new web3.eth.Contract(
-      tokenNetworkAbi,
-      params.tokenNetworkAddress
-    );
-    const txCount = await web3.eth.getTransactionCount(params.address);
-    const open = {
-      nonce: web3.utils.toHex(txCount),
-      gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
-      gasLimit: params.gasLimit || DEFAULT_GAS_LIMIT,
-      to: params.tokenNetworkAddress,
-      value: "0x00",
-      data: tokenNetwork.methods
-        .openChannel(params.address, params.partner, params.settleTimeout || DEFAULT_SETTLE_TIMEOUT)
-        .encodeABI(),
-      chainId,
-    };
-    return open;
-  } catch (e) {
-    throw e;
-  }
+  const { rskEndpoint, chainId } = Lumino.getConfig();
+  const web3 = new Web3(rskEndpoint);
+  const tokenNetwork = new web3.eth.Contract(
+    tokenNetworkAbi,
+    params.tokenNetworkAddress
+  );
+  const txCount = await web3.eth.getTransactionCount(params.address);
+  const open = {
+    nonce: web3.utils.toHex(txCount),
+    gasPrice: params.gasPrice || DEFAULT_GAS_PRICE,
+    gasLimit: params.gasLimit || DEFAULT_GAS_LIMIT,
+    to: params.tokenNetworkAddress,
+    value: "0x00",
+    data: tokenNetwork.methods
+      .openChannel(
+        params.address,
+        params.partner,
+        params.settleTimeout || DEFAULT_SETTLE_TIMEOUT
+      )
+      .encodeABI(),
+    chainId,
+  };
+  return open;
 };

--- a/src/store/actions/close.js
+++ b/src/store/actions/close.js
@@ -6,37 +6,34 @@ import { createCloseTx } from "../../scripts/close";
 import { saveLuminoData } from "./storage";
 
 /**
- * Create a deposit.
+ * Close a channel.
  * @param {string} unsigned_tx- An unsigned close TX
  * @param {string} address -  The address of the creator of the channel
  * @param {string} partner -  The partner address
  * @param {string} token_address -  The address of the lumino token
  */
 export const closeChannel = params => async (dispatch, getState, lh) => {
+  const unsignedCloseTx = await createCloseTx(params);
+  const signed_close_tx = await resolver(unsignedCloseTx, lh);
+
   try {
-    const unsignedCloseTx = await createCloseTx(params);
-    const signed_close_tx = await resolver(unsignedCloseTx, lh);
-    try {
-      const { address, partner, tokenAddress } = params;
-      const requestBody = {
-        signed_approval_tx: "",
-        signed_close_tx,
-        signed_deposit_tx: "",
-        state: "closed",
-      };
-      const url = `light_channels/${tokenAddress}/${address}/${partner}`;
-      const res = await client.patch(url, { ...requestBody });
-      dispatch({
-        type: SET_CHANNEL_CLOSED,
-        channel: { ...res.data, sdk_status: CHANNEL_CLOSED },
-      });
-      const allData = getState();
-      return await lh.storage.saveLuminoData(allData);
-    } catch (apiError) {
-      throw apiError;
-    }
+    const { address, partner, tokenAddress } = params;
+    const requestBody = {
+      signed_approval_tx: "",
+      signed_close_tx,
+      signed_deposit_tx: "",
+      state: "closed",
+    };
+    const url = `light_channels/${tokenAddress}/${address}/${partner}`;
+    const res = await client.patch(url, { ...requestBody });
+    dispatch({
+      type: SET_CHANNEL_CLOSED,
+      channel: { ...res.data, sdk_status: CHANNEL_CLOSED },
+    });
+    const allData = getState();
+    return await lh.storage.saveLuminoData(allData);
   } catch (resolverError) {
-    throw resolverError;
+    console.error(resolverError);
   }
 };
 

--- a/src/store/actions/close.js
+++ b/src/store/actions/close.js
@@ -32,8 +32,8 @@ export const closeChannel = params => async (dispatch, getState, lh) => {
     });
     const allData = getState();
     return await lh.storage.saveLuminoData(allData);
-  } catch (resolverError) {
-    console.error(resolverError);
+  } catch (error) {
+    console.error(error);
   }
 };
 

--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -17,57 +17,53 @@ import { requestTokenNetworkFromTokenAddress } from "./tokens";
  * @param {string} token_address -  The token address for the channel
  */
 export const openChannel = params => async (dispatch, getState, lh) => {
+  const { partner, tokenAddress } = params;
+
+  const clientAddress = getState().client.address;
+  let tokenNetwork = getTokenNetworkByTokenAddress(tokenAddress);
+  if (!tokenNetwork) {
+    tokenNetwork = await dispatch(
+      requestTokenNetworkFromTokenAddress(tokenAddress)
+    );
+  }
+
+  const txParams = {
+    ...params,
+    address: clientAddress,
+    tokenNetworkAddress: tokenNetwork,
+  };
+
+  const unsigned_tx = await createOpenTx(txParams);
+  const signed_tx = await resolver(unsigned_tx, lh);
   try {
-    const { partner, tokenAddress } = params;
-
-    const clientAddress = getState().client.address;
-    let tokenNetwork = getTokenNetworkByTokenAddress(tokenAddress);
-    if (!tokenNetwork) {
-      tokenNetwork = await dispatch(
-        requestTokenNetworkFromTokenAddress(tokenAddress)
-      );
-    }
-
-    const txParams = {
-      ...params,
-      address: clientAddress,
-      tokenNetworkAddress: tokenNetwork,
+    const requestBody = {
+      partner_address: partner,
+      creator_address: clientAddress,
+      token_address: tokenAddress,
+      signed_tx,
     };
 
-    const unsigned_tx = await createOpenTx(txParams);
-    const signed_tx = await resolver(unsigned_tx, lh);
-    try {
-      const requestBody = {
-        partner_address: partner,
-        creator_address: clientAddress,
-        token_address: tokenAddress,
-        signed_tx,
-      };
+    const res = await client.put("light_channels", { ...requestBody });
 
-      const res = await client.put("light_channels", { ...requestBody });
+    const {
+      name: token_name,
+      symbol: token_symbol,
+    } = await requestTokenNameAndSymbol(tokenAddress);
 
-      const {
-        name: token_name,
-        symbol: token_symbol,
-      } = await requestTokenNameAndSymbol(tokenAddress);
+    dispatch({
+      type: OPEN_CHANNEL,
+      channelId: res.data.channel_identifier,
+      channel: {
+        ...res.data,
+        token_symbol,
+        token_name,
+        sdk_status: SDK_CHANNEL_STATUS.CHANNEL_AWAITING_NOTIFICATION,
+      },
+    });
 
-      dispatch({
-        type: OPEN_CHANNEL,
-        channelId: res.data.channel_identifier,
-        channel: {
-          ...res.data,
-          token_symbol,
-          token_name,
-          sdk_status: SDK_CHANNEL_STATUS.CHANNEL_AWAITING_NOTIFICATION,
-        },
-      });
-
-      const allData = getState();
-      await lh.storage.saveLuminoData(allData);
-    } catch (apiError) {
-      throw apiError;
-    }
+    const allData = getState();
+    await lh.storage.saveLuminoData(allData);
   } catch (resolverError) {
-    throw resolverError;
+    console.error(resolverError);
   }
 };

--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -179,6 +179,20 @@ export const addPendingPaymentMessage = (
   });
 
 export const addExpiredPaymentMessage = (
+         paymentId,
+         messageOrder,
+         message,
+         storeInMessages = false
+       ) => dispatch =>
+         dispatch({
+           type: ADD_EXPIRED_PAYMENT_MESSAGE,
+           paymentId,
+           messageOrder,
+           message,
+           storeInMessages,
+         });
+
+export const addExpiredPaymentNormalMessage = (
   paymentId,
   messageOrder,
   message
@@ -188,6 +202,7 @@ export const addExpiredPaymentMessage = (
     paymentId,
     messageOrder,
     message,
+    storeInMessages: true,
   });
 
 const getRandomBN = () => {
@@ -196,24 +211,32 @@ const getRandomBN = () => {
 };
 
 const nonSuccessfulMessageAdd = data => dispatch => {
-  const { paymentId, order, message, message_type_value } = data;
+  const {
+    paymentId,
+    order,
+    message,
+    message_type_value,
+    storeInMessages,
+  } = data;
   switch (message_type_value) {
     case PAYMENT_EXPIRED: {
       return dispatch(
         addExpiredPaymentMessage(paymentId, order, {
           message,
           message_order: order,
-        })
+        },
+        storeInMessages)
       );
     }
   }
 };
 
-export const putDelivered = (message, payment, order = 4) => async (
-  dispatch,
-  getState,
-  lh
-) => {
+export const putDelivered = (
+  message,
+  payment,
+  order = 4,
+  storeInMessages = false
+) => async (dispatch, getState, lh) => {
   // We determine the type for failures or success flows
   const message_type_value = getPaymentMessageTypeValue(payment);
   const { sender, receiver } = getSenderAndReceiver(payment);
@@ -244,6 +267,7 @@ export const putDelivered = (message, payment, order = 4) => async (
         order,
         message: body.message,
         message_type_value,
+        storeInMessages,
       };
       dispatch(nonSuccessfulMessageAdd(data));
     } else {
@@ -263,11 +287,12 @@ export const putDelivered = (message, payment, order = 4) => async (
   }
 };
 
-export const putProcessed = (msg, payment, order = 3) => async (
-  dispatch,
-  getState,
-  lh
-) => {
+export const putProcessed = (
+  msg,
+  payment,
+  order = 3,
+  storeInMessages = false
+) => async (dispatch, getState, lh) => {
   const { sender, receiver } = getSenderAndReceiver(payment);
   const message_type_value = getPaymentMessageTypeValue(payment);
   const { paymentId } = payment;
@@ -295,6 +320,7 @@ export const putProcessed = (msg, payment, order = 3) => async (
         order,
         message: body.message,
         message_type_value,
+        storeInMessages,
       };
       dispatch(nonSuccessfulMessageAdd(data));
     } else {

--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -483,11 +483,6 @@ export const setPaymentFailed = (paymentId, state, reason) => dispatch => {
   return dispatch(obj);
 };
 
-export const setLockExpired = (paymentId, data) => dispatch =>
-  dispatch({
-    type: SET,
-  });
-
 /**
  *
  * @param {*} data Data of the payment and message for the request

--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -263,11 +263,11 @@ export const putDelivered = (message, payment, order = 4) => async (
   }
 };
 
-export const putProcessed = (
-  msg,
-  payment,
-  order = 3
-) => async (dispatch, getState, lh) => {
+export const putProcessed = (msg, payment, order = 3) => async (
+  dispatch,
+  getState,
+  lh
+) => {
   const { sender, receiver } = getSenderAndReceiver(payment);
   const message_type_value = getPaymentMessageTypeValue(payment);
   const { paymentId } = payment;
@@ -290,13 +290,13 @@ export const putProcessed = (
   body.message.signature = signature;
   try {
     if (message_type_value !== PAYMENT_SUCCESSFUL) {
-       const data = {
-         paymentId,
-         order,
-         message: body.message,
-         message_type_value,
-       };
-       dispatch(nonSuccessfulMessageAdd(data));
+      const data = {
+        paymentId,
+        order,
+        message: body.message,
+        message_type_value,
+      };
+      dispatch(nonSuccessfulMessageAdd(data));
     } else {
       dispatch(
         addPendingPaymentMessage(paymentId, order, {
@@ -483,6 +483,11 @@ export const setPaymentFailed = (paymentId, state, reason) => dispatch => {
   return dispatch(obj);
 };
 
+export const setLockExpired = (paymentId, data) => dispatch =>
+  dispatch({
+    type: SET,
+  });
+
 /**
  *
  * @param {*} data Data of the payment and message for the request
@@ -510,6 +515,12 @@ export const putLockExpired = data => async (dispatch, getState, lh) => {
         locksroot: data.locksroot,
       },
     };
+    if (data.signature)
+      return dispatch({
+        type: PUT_LOCK_EXPIRED,
+        paymentId: data.paymentId,
+        lockExpired: body,
+      });
 
     const dataToSign = getDataToSignForLockExpired(body.message);
     const signature = await resolver(dataToSign, lh, true);

--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -540,7 +540,7 @@ export const putLockExpired = data => async (dispatch, getState, lh) => {
         locksroot: data.locksroot,
       },
     };
-    if (data.signature)
+    if (data.signature && data.signature !== "0x")
       return dispatch({
         type: PUT_LOCK_EXPIRED,
         paymentId: data.paymentId,

--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -179,18 +179,18 @@ export const addPendingPaymentMessage = (
   });
 
 export const addExpiredPaymentMessage = (
-         paymentId,
-         messageOrder,
-         message,
-         storeInMessages = false
-       ) => dispatch =>
-         dispatch({
-           type: ADD_EXPIRED_PAYMENT_MESSAGE,
-           paymentId,
-           messageOrder,
-           message,
-           storeInMessages,
-         });
+  paymentId,
+  messageOrder,
+  message,
+  storeInMessages = false
+) => dispatch =>
+  dispatch({
+    type: ADD_EXPIRED_PAYMENT_MESSAGE,
+    paymentId,
+    messageOrder,
+    message,
+    storeInMessages,
+  });
 
 export const addExpiredPaymentNormalMessage = (
   paymentId,
@@ -221,11 +221,15 @@ const nonSuccessfulMessageAdd = data => dispatch => {
   switch (message_type_value) {
     case PAYMENT_EXPIRED: {
       return dispatch(
-        addExpiredPaymentMessage(paymentId, order, {
-          message,
-          message_order: order,
-        },
-        storeInMessages)
+        addExpiredPaymentMessage(
+          paymentId,
+          order,
+          {
+            message,
+            message_order: order,
+          },
+          storeInMessages
+        )
       );
     }
   }

--- a/src/store/functions/channels.js
+++ b/src/store/functions/channels.js
@@ -6,7 +6,11 @@ export const getChannelsState = () => {
   const { channelStates } = store.getState();
   return channelStates;
 };
-
+/**
+ *
+ * @param {*} id The channel identifier
+ * @param {*} token The token address
+ */
 export const getChannelByIdAndToken = (id, token) => {
   const store = Store.getStore();
   const { channelReducer: channels } = store.getState();

--- a/src/store/functions/payments.js
+++ b/src/store/functions/payments.js
@@ -1,4 +1,10 @@
+import { ethers } from "ethers";
 import Store from "../index";
+import {
+  PAYMENT_SUCCESSFUL,
+  PAYMENT_EXPIRED,
+} from "../../config/messagesConstants";
+import { EXPIRED } from "../../config/paymentConstants";
 
 export const getPaymentIds = () => {
   const store = Store.getStore();
@@ -50,4 +56,23 @@ export const getPaymentByIdAndState = (state, paymentId) => {
   if (payments[state.toLowerCase()])
     return payments[state.toLowerCase()][paymentId];
   return null;
+};
+
+export const getPaymentMessageTypeValue = payment => {
+  const isFailed = payment.failureReason;
+  if (!isFailed) return PAYMENT_SUCCESSFUL;
+  switch (payment.failureReason) {
+    case EXPIRED:
+      return PAYMENT_EXPIRED;
+    default:
+      return null;
+  }
+};
+
+export const getSenderAndReceiver = payment => {
+  const { isReceived } = payment;
+  const { getAddress } = ethers.utils;
+  const sender = isReceived ? payment.partner : payment.initiator;
+  const receiver = isReceived ? payment.initiator : payment.partner;
+  return { sender: getAddress(sender), receiver: getAddress(receiver) };
 };

--- a/src/store/functions/payments.js
+++ b/src/store/functions/payments.js
@@ -12,10 +12,32 @@ export const getPaymentIds = () => {
   return paymentIds;
 };
 
-export const getPendingPaymentById = paymentId => {
+export const getAllPayments = () => {
   const store = Store.getStore();
   const { payments } = store.getState();
+  return payments;
+};
+
+export const getPendingPaymentById = paymentId => {
+  const payments = getAllPayments();
   return payments.pending[paymentId];
+};
+
+export const getFailedPaymentById = paymentId => {
+  const payments = getAllPayments();
+
+  return payments.failed[paymentId];
+};
+
+export const getCompletedPaymentById = paymentId => {
+  const payments = getAllPayments();
+  return payments.completed[paymentId];
+};
+
+export const isPaymentCompleteOrPending = paymentId => {
+  const completed = getCompletedPaymentById(paymentId);
+  const pending = getPendingPaymentById(paymentId);
+  return completed || pending;
 };
 
 export const getPendingPayments = () => {

--- a/src/store/reducers/paymentsReducer.js
+++ b/src/store/reducers/paymentsReducer.js
@@ -9,7 +9,6 @@ import {
   PUT_LOCK_EXPIRED,
   ADD_EXPIRED_PAYMENT_MESSAGE,
 } from "../actions/types";
-import { EXPIRED } from "../../config/paymentConstants";
 
 const initialState = {
   pending: {},
@@ -119,8 +118,16 @@ const paymentsReducer = (state = initialState, action) => {
     case ADD_EXPIRED_PAYMENT_MESSAGE: {
       const { messageOrder, message } = action;
       const newState = cloneState(state);
-      newState.failed[paymentId].expiration.messages[messageOrder] = message;
-      newState.failed[paymentId].expiration.message_order = messageOrder;
+      const { failed } = newState;
+      const msg = failed[paymentId].expiration.messages[messageOrder];
+      if (msg && messageOrder === 2) {
+        if (!newState.failed[paymentId].messages)
+          newState.failed[paymentId].messages = {};
+        newState.failed[paymentId].messages[messageOrder] = message;
+      } else {
+        newState.failed[paymentId].expiration.messages[messageOrder] = message;
+        newState.failed[paymentId].expiration.message_order = messageOrder;
+      }
       return newState;
     }
     default:

--- a/src/store/reducers/paymentsReducer.js
+++ b/src/store/reducers/paymentsReducer.js
@@ -9,6 +9,7 @@ import {
   PUT_LOCK_EXPIRED,
   ADD_EXPIRED_PAYMENT_MESSAGE,
 } from "../actions/types";
+import { EXPIRED } from "../../config/paymentConstants";
 
 const initialState = {
   pending: {},

--- a/src/store/reducers/paymentsReducer.js
+++ b/src/store/reducers/paymentsReducer.js
@@ -116,11 +116,9 @@ const paymentsReducer = (state = initialState, action) => {
     }
 
     case ADD_EXPIRED_PAYMENT_MESSAGE: {
-      const { messageOrder, message } = action;
+      const { messageOrder, message, storeInMessages } = action;
       const newState = cloneState(state);
-      const { failed } = newState;
-      const msg = failed[paymentId].expiration.messages[messageOrder];
-      if (msg && messageOrder === 2) {
+      if (storeInMessages) {
         if (!newState.failed[paymentId].messages)
           newState.failed[paymentId].messages = {};
         newState.failed[paymentId].messages[messageOrder] = message;

--- a/src/store/sagas/index.js
+++ b/src/store/sagas/index.js
@@ -16,6 +16,7 @@ import {
   REQUEST_CLIENT_ONBOARDING,
   CLIENT_ONBOARDING_SUCCESS,
   OPEN_CHANNEL_VOTE,
+  SET_CHANNEL_CLOSED,
 } from "../actions/types";
 import { saveLuminoData } from "../actions/storage";
 import { Lumino } from "../../index";
@@ -204,6 +205,10 @@ export function* workClientOnboardingSuccess({ address }) {
   Lumino.callbacks.trigger.triggerOnClientOnboardingSuccess(address);
 }
 
+function workChannelClose({ channel }) {
+  Lumino.callbacks.trigger.triggerOnChannelClose(channel);
+}
+
 export default function* rootSaga() {
   yield takeEvery(MESSAGE_POLLING, workMessagePolling);
   yield takeEvery(CREATE_PAYMENT, workCreatePayment);
@@ -213,4 +218,5 @@ export default function* rootSaga() {
   yield takeEvery(NOTIFICATIONS_POLLING, workNotificationPolling);
   yield takeEvery(REQUEST_CLIENT_ONBOARDING, workRequestClientOnboarding);
   yield takeEvery(CLIENT_ONBOARDING_SUCCESS, workClientOnboardingSuccess);
+  yield takeEvery(SET_CHANNEL_CLOSED, workChannelClose);
 }

--- a/src/store/sagas/index.js
+++ b/src/store/sagas/index.js
@@ -205,8 +205,12 @@ export function* workClientOnboardingSuccess({ address }) {
   Lumino.callbacks.trigger.triggerOnClientOnboardingSuccess(address);
 }
 
-function workChannelClose({ channel }) {
-  Lumino.callbacks.trigger.triggerOnChannelClose(channel);
+function* workChannelClose({ channel }) {
+  const { channel_identifier, token_address } = channel;
+  const channels = yield select(getChannels);
+  const channelKey = `${channel_identifier}-${token_address}`;
+  const channelData = channels[channelKey];
+  Lumino.callbacks.trigger.triggerOnChannelClose(channelData);
 }
 
 export default function* rootSaga() {

--- a/src/utils/callbacks.js
+++ b/src/utils/callbacks.js
@@ -5,6 +5,7 @@ const Callbacks = () => {
 
   let onOpenChannel = () => {};
   let onChannelDeposit = () => {};
+  let onChannelClose = () => {};
 
   let onRequestClientOnboarding = () => {};
   let onClientOnboardingSuccess = () => {};
@@ -14,6 +15,7 @@ const Callbacks = () => {
 
   const setOnOpenChannelCallback = fn => (onOpenChannel = fn);
   const setOnChannelDepositCallback = fn => (onChannelDeposit = fn);
+  const setOnChannelCloseCallback = fn => (onChannelClose = fn);
 
   const setOnRequestClientOnboarding = fn => (onRequestClientOnboarding = fn);
   const setOnClientOnboardingSuccess = fn => (onClientOnboardingSuccess = fn);
@@ -30,6 +32,7 @@ const Callbacks = () => {
 
   const triggerOnOpenChannel = channel => onOpenChannel(channel);
   const triggerOnDepositChannel = channel => onChannelDeposit(channel);
+  const triggerOnChannelClose = channel => onChannelClose(channel);
 
   // Onboarding trigger
 
@@ -46,6 +49,7 @@ const Callbacks = () => {
       triggerOnDepositChannel,
       triggerOnRequestClientOnboarding,
       triggerOnClientOnboardingSuccess,
+      triggerOnChannelClose,
     },
     set: {
       setOnCompletedPaymentCallback,
@@ -54,6 +58,7 @@ const Callbacks = () => {
       setOnChannelDepositCallback,
       setOnRequestClientOnboarding,
       setOnClientOnboardingSuccess,
+      setOnChannelCloseCallback,
     },
   };
 

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -8,7 +8,6 @@ import {
 import {
   FAILURE_REASONS,
   PENDING_PAYMENT,
-  FAILED_PAYMENT,
   EXPIRED,
 } from "../config/paymentConstants";
 import {
@@ -93,7 +92,6 @@ const manageNonPaymentMessages = messages => {
 
     switch (msg.message.type) {
       case MessageType.LOCK_EXPIRED: {
-        if (payment && payment.paymentState === FAILED_PAYMENT) return null;
         return manageLockExpired(msg, payment);
       }
       case MessageType.DELIVERED:
@@ -210,9 +208,10 @@ const manageLockedTransfer = (message, payment, messageKey) => {
   const msg = message[messageKey];
 
   if (payment && payment.failureReason) {
-    return store.dispatch(
+    store.dispatch(
       putDelivered(msg, payment, message.message_order + 1, PAYMENT_SUCCESSFUL)
     );
+    return store.dispatch(putProcessed(msg, payment, 3, PAYMENT_SUCCESSFUL));
   }
 
   // Validate signature
@@ -272,7 +271,7 @@ const manageLockedTransfer = (message, payment, messageKey) => {
   store.dispatch(
     putDelivered(msg, actionObj.payment, message.message_order + 1)
   );
-  store.dispatch(putProcessed(msg, actionObj.payment, 3, PAYMENT_SUCCESSFUL));
+  store.dispatch(putProcessed(msg, actionObj.payment, 3));
 };
 
 /**

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -4,7 +4,6 @@ import {
   MessageKeyForOrder,
   LIGHT_MESSAGE_TYPE,
   PAYMENT_SUCCESSFUL,
-  PAYMENT_EXPIRED,
 } from "../config/messagesConstants";
 import {
   FAILURE_REASONS,

--- a/src/utils/pack.js
+++ b/src/utils/pack.js
@@ -32,7 +32,7 @@ const hexEncode = (data, length, isUnsafe) => {
  * @param {number} lockedAmount - The tx locked amount
  * @param {string} locksRoot - The hexadecimal string of the locksroot
  */
-const createBalanceHash = (txAmount, lockedAmount, locksRoot) => {
+export const createBalanceHash = (txAmount, lockedAmount, locksRoot) => {
   const { HashZero } = ethers.constants;
   const txAmountHex = hexEncode(txAmount, 32, true);
   const lockedAmountHex = hexEncode(lockedAmount, 32, true);
@@ -50,6 +50,25 @@ const createBalanceHash = (txAmount, lockedAmount, locksRoot) => {
     locksRootHex,
   ]);
   return ethers.utils.keccak256(toHash);
+};
+
+export const createMessageHash = (data, type = MessageType.BALANCE_PROOF) => {
+  const messageHashUnhashed = ethers.utils.concat([
+    hexEncode(MessageNumPad[type], 1),
+    hexEncode(0, 3),
+    hexEncode(data.chain_id, 32),
+    hexEncode(data.message_identifier, 8, true),
+    hexEncode(data.payment_identifier, 8, true),
+    hexEncode(data.token_network_address, 20),
+    hexEncode(data.secret, 32),
+    hexEncode(data.nonce, 8),
+    hexEncode(data.channel_identifier, 32),
+    hexEncode(data.transferred_amount, 32, true),
+    hexEncode(data.locked_amount, 32, true),
+    hexEncode(data.locksroot, 32),
+  ]);
+
+  return ethers.utils.keccak256(messageHashUnhashed);
 };
 
 // TODO: Separate the methods and document their uses according to messages

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -5,7 +5,7 @@ import Lumino from "../Lumino/index";
 
 /**
  *
- * @param {arrayish} message The message with the signature to be checked
+ * @param {arrayish} message The message with the signature
  */
 export const signatureRecover = message => {
   const { verifyMessage } = ethers.utils;


### PR DESCRIPTION
This PR requires #40 to be merged first.

This PR includes changes to the close channel script, so it can now generate the needed hashes for the on-chain transaction of close channel.

- Now a channel can be closed with balance
- The last balance proof from a partner is used to compose the necessary values
- No changes were made from the user side to the required params.
- Some variables were renamed to be more concise with their origin
- A callback for the close channel completion was added.