### PR TITLE
Fix close channel parameter in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Requests the close of a channel that is opened, the requestBody is the next:
 ```javascript
 const requestBody = {
 	partner_address: "0x123...",
-	channelId: Number
+	channel_identifier: Number
 	token_address: "0x987..."
 };
 ```


### PR DESCRIPTION
When we were testing we discovered the next:

The parameter in the close channel function that is named **channelId** is actually used internally as **channel_identifier** therefore, the SDK can not perform a close channel correctly.

This PR aims to fix that documentation issue.