### PR TITLE
Fix prepublishOnly hook, add @rsksmart scope to readme imports, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The SDK gives the developer all the functions to work with a Lumino HUB and inte
 
 **Yarn**
 
-`yarn install lumino-light-client-sdk`
+`yarn install @rsksmart/lumino-light-client-sdk`
 
 **NPM**
 
-`npm install --save lumino-light-client-sdk`
+`npm install --save @rsksmart/lumino-light-client-sdk`
 
 ## Starting
 
 ```javascript
-import { Lumino } from "lumino-light-client-sdk";
+import { Lumino } from "@rsksmart/lumino-light-client-sdk";
 ```
 
 Lumino is our main interface to interact with the SDK.
@@ -61,7 +61,7 @@ In order to make the setup more easier, we provided a default handler,
 in the form of SigningHandler, which can be imported from the sdk
 
 ```javascript
-import {SigningHandler} from 'lumino-light-client-sdk"
+import { SigningHandler } from "@rsksmart/lumino-light-client-sdk";
 
 const signingHandler = SigningHandler();
 
@@ -95,7 +95,7 @@ saveLuminoData(data: Object) => void
 This method saves the data that the SDK has stored in memory, implementations can also be of any type, it must accept a parameter (**data**) which is a JS object containing the data of the SDK.
 
 ```javascript
-import {LocalStorageHandler} from 'lumino-light-client-sdk"
+import { LocalStorageHandler } from "@rsksmart/lumino-light-client-sdk";
 ```
 
 We also provide a default implementation of the handler in the SDK, this is for a web enviroment and can be imported from the SDK.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/lumino-light-client-sdk",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "Lumino Light Client SDK for JS",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node index.js",
     "build": "npx gulp babel",
     "prettier": "prettier --print-width 80 --end-of-line lf --trailing-comma es5 --write 'src/**/*.js'",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "keywords": [
     "lumino",


### PR DESCRIPTION
The readme had all the imports using the package without the rsksmart scope, I have modified them to reflect the correct imports.

As well as changing the prepublishOnly hook to prepare, since the dist folder will not be included
See https://github.com/npm/npm/issues/15147

The version of the package was bumped to 0.0.3, to match the Lumino Node release version.
