### PR TITLE
RLP-723 Do not send API key on onboarding

### DIFF
--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -8,10 +8,13 @@ import {
 } from "../actions/types";
 import { Lumino } from "../..";
 import { CALLBACKS } from "../../utils/callbacks";
+import { stopAllPolling } from "./polling";
 
 export const onboardingClient = () => async (dispatch, getState, lh) => {
   const address = getState().client.address;
   try {
+    dispatch(stopAllPolling());
+    client.defaults.headers = {};
     const urlOnboard = "light_clients/matrix/credentials";
     const onboardReq = await client.get(urlOnboard, { params: { address } });
     // We get the data

--- a/test/store/actions/onboarding.test.js
+++ b/test/store/actions/onboarding.test.js
@@ -49,8 +49,8 @@ describe("test onboarding behaviour", () => {
 
 
     expect(client.defaults.headers["x-api-key"]).toBe(mockApiKey);
-    expect(actions.length).toBe(4);
-    expect(actions[2]).toStrictEqual({ type: MESSAGE_POLLING_START });
+    expect(actions.length).toBe(6);
+    expect(actions[4]).toStrictEqual({ type: MESSAGE_POLLING_START });
   });
 
   test("should trigger failure on non successfull onboarding", async () => {


### PR DESCRIPTION
This PR aims to fix a behaviour of storing only one API Key.

If we store the API key and change the hub that we use, the api key is stale and will be used in all operations.
When we want to perform and onboarding, the api key will be sent, and the hub will reject our request (due to the invalid api key)

With this PR now the api key is removed from the request before it is sent.

The test for the onboarding was fixed due to an extra measure, stop the polling (in order to prevent stalled requests)