### PR TITLE
RLP-718 Open channel only when hub has answered

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -3,4 +3,13 @@ const mockAxios = jest.genMockFromModule("axios");
 // this is the key to fix the axios.create() undefined error!
 mockAxios.create = jest.fn(() => mockAxios);
 
+mockAxios.CancelToken = {
+  source: jest.fn(() => {
+    return {
+      token: "CancelToken",
+      cancel: () => jest.fn(),
+    };
+  }),
+};
+
 export default mockAxios;

--- a/src/store/actions/notifier.js
+++ b/src/store/actions/notifier.js
@@ -335,12 +335,11 @@ const manageNewChannel = async (notification, notifier) => {
   let partner_address = getAddress(values[1].value);
   // We check it to make sure to get the correct partner
   let openedByUser = true;
-  
+
   if (partner_address === getAddress(selfAddress)) {
     partner_address = getAddress(values[2].value);
     openedByUser = false;
   }
-
 
   if (!existingChannel) {
     // We need the structure there to give it votes, if there isn't one, we create one

--- a/src/store/actions/notifier.js
+++ b/src/store/actions/notifier.js
@@ -330,11 +330,17 @@ const manageNewChannel = async (notification, notifier) => {
   );
   const selfAddress = getState().client.address;
 
+  // NOTE: The opener of the channel is the value[1] which is the first address
+
   let partner_address = getAddress(values[1].value);
   // We check it to make sure to get the correct partner
-
-  if (partner_address === getAddress(selfAddress))
+  let openedByUser = true;
+  
+  if (partner_address === getAddress(selfAddress)) {
     partner_address = getAddress(values[2].value);
+    openedByUser = false;
+  }
+
 
   if (!existingChannel) {
     // We need the structure there to give it votes, if there isn't one, we create one
@@ -344,6 +350,7 @@ const manageNewChannel = async (notification, notifier) => {
 
     const channel = createChannelFromNotification({
       ...values,
+      openedByUser,
       channel_identifier,
       token_network_identifier,
       token_name,
@@ -389,6 +396,7 @@ const createChannelFromNotification = data => ({
   token_address: data.token_address,
   token_name: data.token_name,
   token_symbol: data.token_symbol,
+  openedByUser: data.openedByUser,
   balance: "0",
   state: "opened",
   total_deposit: "0",

--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -12,7 +12,7 @@ import {
 import { requestTokenNetworkFromTokenAddress } from "./tokens";
 import { Lumino } from "../..";
 import { CALLBACKS } from "../../utils/callbacks";
-import { TIMEOUT_MAP, ONE_MINUTE_IN_MS } from "../../utils/timeoutValues";
+import { TIMEOUT_MAP } from "../../utils/timeoutValues";
 import Axios from "axios";
 
 /**
@@ -93,7 +93,7 @@ export const openChannel = params => async (dispatch, getState, lh) => {
         new Error("The operation took too much time")
       );
       source.cancel();
-    }, currentTimeout + 50);
+    }, currentTimeout);
 
     Lumino.callbacks.trigger(CALLBACKS.REQUEST_OPEN_CHANNEL, channel);
 

--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -33,8 +33,7 @@ export const openChannel = params => async (dispatch, getState, lh) => {
     console.log("Resolved address", partner);
     if (partner === "0x0000000000000000000000000000000000000000"){
       Lumino.callbacks.trigger(CALLBACKS.FAILED_OPEN_CHANNEL, channel, "RNS domain isnt registered");
-      console.error(error);
-    }else{
+    } else{
       params.partner = partner;
     }
   }
@@ -85,6 +84,8 @@ export const openChannel = params => async (dispatch, getState, lh) => {
       channel: {
         ...res.data,
         token_symbol,
+        hubAnswered: true,
+        openedByUser: true,
         token_name,
         sdk_status: SDK_CHANNEL_STATUS.CHANNEL_AWAITING_NOTIFICATION,
       },

--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -3,10 +3,8 @@ import { SDK_CHANNEL_STATUS } from "../../config/channelStates";
 import client from "../../apiRest";
 import resolver from "../../utils/handlerResolver";
 import { createOpenTx } from "../../scripts/open";
-import {isRnsDomain} from "../../utils/functions";
-import {
-  getRnsInstance
-} from "../functions/rns";
+import { isRnsDomain } from "../../utils/functions";
+import { getRnsInstance } from "../functions/rns";
 import {
   getTokenNetworkByTokenAddress,
   requestTokenNameAndSymbol,
@@ -14,6 +12,8 @@ import {
 import { requestTokenNetworkFromTokenAddress } from "./tokens";
 import { Lumino } from "../..";
 import { CALLBACKS } from "../../utils/callbacks";
+import { TIMEOUT_MAP, ONE_MINUTE_IN_MS } from "../../utils/timeoutValues";
+import Axios from "axios";
 
 /**
  * Open a channel.
@@ -27,13 +27,17 @@ export const openChannel = params => async (dispatch, getState, lh) => {
   let { partner } = params;
 
   // Check if partner is a rns domain
-  if(isRnsDomain(partner)){
+  if (isRnsDomain(partner)) {
     const rns = getRnsInstance();
     partner = await rns.addr(partner);
     console.log("Resolved address", partner);
-    if (partner === "0x0000000000000000000000000000000000000000"){
-      Lumino.callbacks.trigger(CALLBACKS.FAILED_OPEN_CHANNEL, channel, "RNS domain isnt registered");
-    } else{
+    if (partner === "0x0000000000000000000000000000000000000000") {
+      Lumino.callbacks.trigger(
+        CALLBACKS.FAILED_OPEN_CHANNEL,
+        channel,
+        "RNS domain isnt registered"
+      );
+    } else {
       params.partner = partner;
     }
   }
@@ -75,8 +79,31 @@ export const openChannel = params => async (dispatch, getState, lh) => {
 
     requestBody.signed_tx = signed_tx;
 
+    // Timeout setup
+    const { chainId } = Lumino.getConfig().chainId;
+    const currentTimeout = TIMEOUT_MAP[chainId] || TIMEOUT_MAP[31];
+    // Cancellation setup
+    const CancelToken = Axios.CancelToken;
+    const source = CancelToken.source();
+
+    const timeoutId = setTimeout(() => {
+      Lumino.callbacks.trigger(
+        CALLBACKS.TIMED_OUT_OPEN_CHANNEL,
+        channel,
+        new Error("The operation took too much time")
+      );
+      source.cancel();
+    }, currentTimeout + 50);
+
     Lumino.callbacks.trigger(CALLBACKS.REQUEST_OPEN_CHANNEL, channel);
-    const res = await client.put("light_channels", { ...requestBody });
+
+    const res = await client.put(
+      "light_channels",
+      { ...requestBody },
+      { cancelToken: source.token }
+    );
+
+    clearTimeout(timeoutId);
 
     dispatch({
       type: OPEN_CHANNEL,

--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -81,7 +81,7 @@ export const openChannel = params => async (dispatch, getState, lh) => {
 
     // Timeout setup
     const { chainId } = Lumino.getConfig().chainId;
-    const currentTimeout = TIMEOUT_MAP[chainId] || TIMEOUT_MAP[31];
+    const currentTimeout = TIMEOUT_MAP[chainId] || TIMEOUT_MAP[30];
     // Cancellation setup
     const CancelToken = Axios.CancelToken;
     const source = CancelToken.source();

--- a/src/store/reducers/channelReducer.js
+++ b/src/store/reducers/channelReducer.js
@@ -81,7 +81,7 @@ const channel = (state = initialState, action) => {
         const channelWithResponse = {...state[nChannelKey],
         hubAnswered: true
         };
-        return {...state, nChannelKey: channelWithResponse};
+        return {...state, [nChannelKey]: channelWithResponse};
       }
       const newChannels = createChannel(state, action.channel, nChannelKey, true);
       return newChannels;

--- a/src/store/reducers/channelReducer.js
+++ b/src/store/reducers/channelReducer.js
@@ -78,13 +78,19 @@ const channel = (state = initialState, action) => {
       const nChannelKey = getChannelKey(action.channel);
       // We don't open if it is already there
       if (state[nChannelKey]) {
-        const channelWithResponse = {...state[nChannelKey],
-        hubAnswered: true,
-        openedByUser: true
+        const channelWithResponse = {
+          ...state[nChannelKey],
+          hubAnswered: true,
+          openedByUser: true,
         };
-        return {...state, [nChannelKey]: channelWithResponse};
+        return { ...state, [nChannelKey]: channelWithResponse };
       }
-      const newChannels = createChannel(state, action.channel, nChannelKey, true);
+      const newChannels = createChannel(
+        state,
+        action.channel,
+        nChannelKey,
+        true
+      );
       return newChannels;
     }
 
@@ -116,15 +122,15 @@ const channel = (state = initialState, action) => {
       // If we have the half + 1 votes of approval, we open the channel
       // Also we need the hub to have answered the request and we opened the channel
 
-      const {openedByUser} = ovChannel[ovChannelKey];
+      const { openedByUser } = ovChannel[ovChannelKey];
       // If user is the opener the hub mas have answered, if not we can open it with the votes alone.
       const canBeOpened =
         !openedByUser || (openedByUser && ovChannel[ovChannelKey].hubAnswered);
 
       // Needed votes to be opened
-      const neededVotes = Math.ceil(numberOfNotifiers / 2); 
+      const neededVotes = Math.ceil(numberOfNotifiers / 2);
 
-      if ((openVotesQuantity >= neededVotes) && canBeOpened)
+      if (openVotesQuantity >= neededVotes && canBeOpened)
         ovChannel[ovChannelKey].sdk_status = SDK_CHANNEL_STATUS.CHANNEL_OPENED;
 
       return ovChannel;

--- a/src/store/reducers/channelReducer.js
+++ b/src/store/reducers/channelReducer.js
@@ -79,7 +79,8 @@ const channel = (state = initialState, action) => {
       // We don't open if it is already there
       if (state[nChannelKey]) {
         const channelWithResponse = {...state[nChannelKey],
-        hubAnswered: true
+        hubAnswered: true,
+        openedByUser: true
         };
         return {...state, [nChannelKey]: channelWithResponse};
       }

--- a/src/utils/callbacks.js
+++ b/src/utils/callbacks.js
@@ -17,6 +17,7 @@ const FAILED_DEPOSIT_CHANNEL = "FailedDepositChannel";
 const FAILED_CLOSE_CHANNEL = "FailedCloseChannel";
 const FAILED_PAYMENT = "FailedPayment";
 const FAILED_CREATE_PAYMENT = "FailedCreatePayment";
+const TIMED_OUT_OPEN_CHANNEL = "TimedOutOpenChannel";
 
 export const CALLBACKS = {
   RECEIVED_PAYMENT,
@@ -38,6 +39,7 @@ export const CALLBACKS = {
   FAILED_PAYMENT,
   FAILED_CREATE_PAYMENT,
   CLIENT_ONBOARDING_FAILURE,
+  TIMED_OUT_OPEN_CHANNEL,
 };
 
 const Callbacks = () => {

--- a/src/utils/timeoutValues.js
+++ b/src/utils/timeoutValues.js
@@ -5,7 +5,6 @@ export const ONE_MINUTE_IN_MS = 60000;
  */
 export const TIMEOUT_MAP = {
   33: ONE_MINUTE_IN_MS * 5,
-  32: ONE_MINUTE_IN_MS * 30,
   31: ONE_MINUTE_IN_MS * 30,
   30: ONE_MINUTE_IN_MS * 30,
 };

--- a/src/utils/timeoutValues.js
+++ b/src/utils/timeoutValues.js
@@ -1,0 +1,11 @@
+export const ONE_MINUTE_IN_MS = 60000;
+
+/**
+ * We change the values according to the chain_id
+ */
+export const TIMEOUT_MAP = {
+    33: ONE_MINUTE_IN_MS * 5,
+    32: ONE_MINUTE_IN_MS * 30,
+    31: ONE_MINUTE_IN_MS * 30
+};
+

--- a/src/utils/timeoutValues.js
+++ b/src/utils/timeoutValues.js
@@ -4,8 +4,7 @@ export const ONE_MINUTE_IN_MS = 60000;
  * We change the values according to the chain_id
  */
 export const TIMEOUT_MAP = {
-    33: ONE_MINUTE_IN_MS * 5,
-    32: ONE_MINUTE_IN_MS * 30,
-    31: ONE_MINUTE_IN_MS * 30
+  33: ONE_MINUTE_IN_MS * 5,
+  32: ONE_MINUTE_IN_MS * 30,
+  31: ONE_MINUTE_IN_MS * 30,
 };
-

--- a/src/utils/timeoutValues.js
+++ b/src/utils/timeoutValues.js
@@ -7,4 +7,5 @@ export const TIMEOUT_MAP = {
   33: ONE_MINUTE_IN_MS * 5,
   32: ONE_MINUTE_IN_MS * 30,
   31: ONE_MINUTE_IN_MS * 30,
+  30: ONE_MINUTE_IN_MS * 30,
 };

--- a/test/store/actions/open.test.js
+++ b/test/store/actions/open.test.js
@@ -18,6 +18,8 @@ const address = "0x920984391853d81CCeeC41AdB48a45D40594A0ec";
 const randomPartner = "0xB59ef6015d0e5d46AC9515dcd3f8b928Bb7F87d3";
 const randomAddress = "0xe3066B701f4a3eC8EcAA6D63ADc45180e5022bA3";
 
+jest.useFakeTimers();
+
 describe("test open channel action", () => {
   const spyOpen = jest.spyOn(openScripts, "createOpenTx");
   const spyResolver = jest.spyOn(signatureResolver, "default");
@@ -84,6 +86,8 @@ describe("test open channel action", () => {
     const expectedAction = {
       channel: {
         channel_identifier: 1,
+        hubAnswered: true,
+        openedByUser: true,
         sdk_status: "CHANNEL_AWAITING_NOTIFICATION",
         token_name: "LUMINO",
         token_symbol: "LUM",


### PR DESCRIPTION
Because of some issues with the timing when a hub opens a channel and the LC inmediately requests a deposit, we changed the approach that we consider when a channel is properly opened.

- We take in account the notifiers as before
- But we also require the hub to have answered
- The requests may not take more than 5 minutes in regtest, or 30 in mainnet/testnet
- If they take more than that, the request will be canceled, and a callback will be fired