### PR TITLE
Bugfix/rifex 166 - Fix issues when notifiers open a channel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4329,6 +4329,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "await-semaphore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/await-semaphore/-/await-semaphore-0.1.3.tgz",
+      "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q=="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -5674,6 +5679,11 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer": {
       "version": "4.9.2",
@@ -7532,6 +7542,110 @@
         "js-sha3": "^0.5.7"
       }
     },
+    "eth-json-rpc-errors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
+      "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
+    "eth-json-rpc-filters": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz",
+      "integrity": "sha512-GkXb2h6STznD+AmMzblwXgm1JMvjdK9PTIXG7BvIkTlXQ9g0QOxuU1iQRYHoslF9S30BYBSoLSisAYPdLggW+A==",
+      "requires": {
+        "await-semaphore": "^0.1.3",
+        "eth-json-rpc-middleware": "^4.1.4",
+        "eth-query": "^2.1.2",
+        "json-rpc-engine": "^5.1.3",
+        "lodash.flatmap": "^4.5.0",
+        "safe-event-emitter": "^1.0.1"
+      },
+      "dependencies": {
+        "eth-json-rpc-middleware": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz",
+          "integrity": "sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==",
+          "requires": {
+            "btoa": "^1.2.1",
+            "clone": "^2.1.1",
+            "eth-json-rpc-errors": "^1.0.1",
+            "eth-query": "^2.1.2",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.6.0",
+            "ethereumjs-tx": "^1.3.7",
+            "ethereumjs-util": "^5.1.2",
+            "ethereumjs-vm": "^2.6.0",
+            "fetch-ponyfill": "^4.0.0",
+            "json-rpc-engine": "^5.1.3",
+            "json-stable-stringify": "^1.0.1",
+            "pify": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
+          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "json-rpc-engine": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.1.8.tgz",
+          "integrity": "sha512-vTBSDEPJV1fPAsbm2g5sEuPjsgLdiab2f1CTn2PyRr8nxggUpA996PDlNQDsM0gnrA99F8KIBLq2nIKrOFl1Mg==",
+          "requires": {
+            "async": "^2.0.1",
+            "eth-json-rpc-errors": "^2.0.1",
+            "promise-to-callback": "^1.0.0",
+            "safe-event-emitter": "^1.0.1"
+          },
+          "dependencies": {
+            "eth-json-rpc-errors": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz",
+              "integrity": "sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==",
+              "requires": {
+                "fast-safe-stringify": "^2.0.6"
+              }
+            }
+          }
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
+      }
+    },
     "eth-json-rpc-infura": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.1.tgz",
@@ -8814,6 +8928,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -15397,6 +15516,11 @@
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
       "dev": true
     },
+    "lodash.flatmap": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
+      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -20689,8 +20813,10 @@
         "backoff": "^2.5.0",
         "clone": "^2.0.0",
         "cross-fetch": "^2.1.0",
-        "eth-block-tracker": "^3.0.0",
+        "eth-block-tracker": "^4.2.0",
+        "eth-json-rpc-filters": "^4.0.2",
         "eth-json-rpc-infura": "^3.1.0",
+        "eth-json-rpc-middleware": "^4.1.1",
         "eth-sig-util": "^1.4.2",
         "ethereumjs-block": "^1.2.2",
         "ethereumjs-tx": "^1.2.0",
@@ -20707,6 +20833,27 @@
         "xtend": "^4.0.1"
       },
       "dependencies": {
+        "eth-json-rpc-middleware": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz",
+          "integrity": "sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==",
+          "requires": {
+            "btoa": "^1.2.1",
+            "clone": "^2.1.1",
+            "eth-json-rpc-errors": "^1.0.1",
+            "eth-query": "^2.1.2",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.6.0",
+            "ethereumjs-tx": "^1.3.7",
+            "ethereumjs-util": "^5.1.2",
+            "ethereumjs-vm": "^2.6.0",
+            "fetch-ponyfill": "^4.0.0",
+            "json-rpc-engine": "^5.1.3",
+            "json-stable-stringify": "^1.0.1",
+            "pify": "^3.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
         "ethereumjs-tx": {
           "version": "1.3.7",
           "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
@@ -20730,6 +20877,27 @@
             "secp256k1": "^3.0.1"
           }
         },
+        "json-rpc-engine": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.1.8.tgz",
+          "integrity": "sha512-vTBSDEPJV1fPAsbm2g5sEuPjsgLdiab2f1CTn2PyRr8nxggUpA996PDlNQDsM0gnrA99F8KIBLq2nIKrOFl1Mg==",
+          "requires": {
+            "async": "^2.0.1",
+            "eth-json-rpc-errors": "^2.0.1",
+            "promise-to-callback": "^1.0.0",
+            "safe-event-emitter": "^1.0.1"
+          },
+          "dependencies": {
+            "eth-json-rpc-errors": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz",
+              "integrity": "sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==",
+              "requires": {
+                "fast-safe-stringify": "^2.0.6"
+              }
+            }
+          }
+        },
         "keccak": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
@@ -20740,6 +20908,11 @@
             "nan": "^2.2.1",
             "safe-buffer": "^5.1.0"
           }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "ws": {
           "version": "5.2.2",

--- a/src/store/actions/notifier.js
+++ b/src/store/actions/notifier.js
@@ -330,14 +330,14 @@ const manageNewChannel = async (notification, notifier) => {
   );
   const selfAddress = getState().client.address;
 
-  // NOTE: The opener of the channel is the value[1] which is the first address
+  // NOTE: The opener of the channel is the value[2] which is the first address
 
-  let partner_address = getAddress(values[1].value);
+  let partner_address = getAddress(values[2].value);
   // We check it to make sure to get the correct partner
   let openedByUser = true;
 
   if (partner_address === getAddress(selfAddress)) {
-    partner_address = getAddress(values[2].value);
+    partner_address = getAddress(values[1].value);
     openedByUser = false;
   }
 

--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -14,6 +14,7 @@ import { Lumino } from "../..";
 import { CALLBACKS } from "../../utils/callbacks";
 import { TIMEOUT_MAP } from "../../utils/timeoutValues";
 import Axios from "axios";
+import { getNumberOfNotifiers } from "../functions/notifiers";
 
 /**
  * Open a channel.
@@ -105,9 +106,12 @@ export const openChannel = params => async (dispatch, getState, lh) => {
 
     clearTimeout(timeoutId);
 
+    const numberOfNotifiers = getNumberOfNotifiers();
+
     dispatch({
       type: OPEN_CHANNEL,
       channelId: res.data.channel_identifier,
+      numberOfNotifiers,
       channel: {
         ...res.data,
         token_symbol,

--- a/src/store/actions/open.js
+++ b/src/store/actions/open.js
@@ -106,7 +106,7 @@ export const openChannel = params => async (dispatch, getState, lh) => {
 
     clearTimeout(timeoutId);
 
-    const numberOfNotifiers = getNumberOfNotifiers();
+    const numberOfNotifiers = Object.keys(getState().notifier.notifiers).length;
 
     dispatch({
       type: OPEN_CHANNEL,

--- a/src/store/sagas/index.js
+++ b/src/store/sagas/index.js
@@ -15,7 +15,7 @@ import {
   OPEN_CHANNEL_VOTE,
   CLOSE_CHANNEL_VOTE,
   SET_PAYMENT_FAILED,
-  CLIENT_ONBOARDING_FAILURE,
+  OPEN_CHANNEL,
 } from "../actions/types";
 import { saveLuminoData } from "../actions/storage";
 import { Lumino } from "../../index";
@@ -230,11 +230,16 @@ export function* workClientOnboardingSuccess({ address }) {
   );
 }
 
+export function* workOpenChannel({ channel }) {
+  return yield Lumino.callbacks.trigger(CALLBACKS.OPEN_CHANNEL, channel);
+}
+
 export default function* rootSaga() {
   yield takeEvery(MESSAGE_POLLING, workMessagePolling);
   yield takeEvery(CREATE_PAYMENT, workCreatePayment);
   yield takeEvery(SET_PAYMENT_COMPLETE, workPaymentComplete);
   yield takeEvery(RECEIVED_PAYMENT, workReceivedPayment);
+  yield takeEvery(OPEN_CHANNEL, workOpenChannel);
   yield takeEvery(NEW_DEPOSIT, workDepositChannel);
   yield takeEvery(NOTIFICATIONS_POLLING, workNotificationPolling);
   yield takeEvery(REQUEST_CLIENT_ONBOARDING, workRequestClientOnboarding);

--- a/test/store/actions/open.test.js
+++ b/test/store/actions/open.test.js
@@ -36,6 +36,9 @@ describe("test open channel action", () => {
     client: {
       address,
     },
+    notifier: {
+      notifiers: {}
+    }
   };
 
   afterEach(() => {
@@ -93,6 +96,7 @@ describe("test open channel action", () => {
         token_symbol: "LUM",
       },
       channelId: 1,
+      numberOfNotifiers: 0,
       type: "OPEN_CHANNEL",
     };
     expect(actions[0]).toStrictEqual(expectedAction);


### PR DESCRIPTION
In our architecture, we use the notifiers as a means to ensure that a channel was properly opened.
But the notifiers were opening the channels in spite of the checks that we placed.
There was a typo in a number of the notifiers values, that made that behaviour happen.

- The typo was fixed
- Some logic was reused (since the open channel votes may or may not open the channel, as well as the Open channel from the hub request)
- A test was fixed