### PR TITLE
RIFEX-177 Make deposit accumulative

### DIFF
--- a/src/store/actions/deposit.js
+++ b/src/store/actions/deposit.js
@@ -8,7 +8,6 @@ import { Lumino } from "../..";
 import { CALLBACKS } from "../../utils/callbacks";
 import BigNumber from "bignumber.js";
 
-
 /**
  * Create a deposit.
  * @param {string} unsigned_approval_tx - An unsigned approval TX
@@ -21,8 +20,7 @@ export const createDeposit = params => async (dispatch, getState, lh) => {
   const { partner, channelId, tokenAddress } = params;
   let { amount } = params;
   const channel = getChannelByIdAndToken(channelId, tokenAddress);
-  amount = new BigNumber().plus(channel.total_deposit).toString();
-
+  amount = new BigNumber(amount).plus(channel.total_deposit).toString();
   try {
     const clientAddress = getState().client.address;
 

--- a/src/store/actions/deposit.js
+++ b/src/store/actions/deposit.js
@@ -20,7 +20,23 @@ export const createDeposit = params => async (dispatch, getState, lh) => {
   const { partner, channelId, tokenAddress } = params;
   let { amount } = params;
   const channel = getChannelByIdAndToken(channelId, tokenAddress);
-  amount = new BigNumber(amount).plus(channel.total_deposit).toString();
+  const { offChainBalance, total_deposit } = channel;
+  amount = new BigNumber(amount).plus(offChainBalance).toString();
+  const currentTotalDeposit = new BigNumber(total_deposit);
+
+  // We check that the new deposit is enough, if not, we trigger a proper callback
+  if (currentTotalDeposit.isGreaterThanOrEqualTo(amount)) {
+    const valueDifference = currentTotalDeposit.minus(amount).toString();
+    const error = new Error(
+      `The current deposit is ${currentTotalDeposit.toString()} and the final amount is ${amount}, the amount must be greater than the deposit, difference ${valueDifference}`
+    );
+    return Lumino.callbacks.trigger(
+      CALLBACKS.DEPOSIT_CHANNEL_VALUE_TOO_LOW,
+      { currentDeposit: total_deposit, valueDifference, amount },
+      error
+    );
+  }
+
   try {
     const clientAddress = getState().client.address;
 
@@ -40,7 +56,7 @@ export const createDeposit = params => async (dispatch, getState, lh) => {
       signed_close_tx: "",
     };
     const url = `light_channels/${tokenAddress}/${clientAddress}/${partner}`;
-    Lumino.callbacks.trigger(CALLBACKS.REQUEST_DEPOSIT_CHANNEL, channel);
+    Lumino.callbacks.trigger(CALLBACKS.REQUEST_DEPOSIT_CHANNEL, {...channel, amount});
     const res = await client.patch(url, { ...requestBody });
     dispatch({
       type: NEW_DEPOSIT,

--- a/src/store/actions/deposit.js
+++ b/src/store/actions/deposit.js
@@ -6,6 +6,8 @@ import { createApprovalTx, createDepositTx } from "../../scripts/deposit";
 import { getChannelByIdAndToken } from "../functions";
 import { Lumino } from "../..";
 import { CALLBACKS } from "../../utils/callbacks";
+import BigNumber from "bignumber.js";
+
 
 /**
  * Create a deposit.
@@ -16,8 +18,11 @@ import { CALLBACKS } from "../../utils/callbacks";
  * @param {string} total_deposit -  The amount to deposit
  */
 export const createDeposit = params => async (dispatch, getState, lh) => {
-  const { amount, partner, channelId, tokenAddress } = params;
+  const { partner, channelId, tokenAddress } = params;
+  let { amount } = params;
   const channel = getChannelByIdAndToken(channelId, tokenAddress);
+  amount = new BigNumber().plus(channel.total_deposit).toString();
+
   try {
     const clientAddress = getState().client.address;
 

--- a/src/utils/callbacks.js
+++ b/src/utils/callbacks.js
@@ -14,6 +14,7 @@ const SENT_PAYMENT = "SentPayment";
 const SIGNING_FAIL = "SigningFail";
 const FAILED_OPEN_CHANNEL = "FailedOpenChannel";
 const FAILED_DEPOSIT_CHANNEL = "FailedDepositChannel";
+const DEPOSIT_CHANNEL_VALUE_TOO_LOW = "DepositChannelValueTooLow";
 const FAILED_CLOSE_CHANNEL = "FailedCloseChannel";
 const FAILED_PAYMENT = "FailedPayment";
 const FAILED_CREATE_PAYMENT = "FailedCreatePayment";
@@ -40,6 +41,7 @@ export const CALLBACKS = {
   FAILED_CREATE_PAYMENT,
   CLIENT_ONBOARDING_FAILURE,
   TIMED_OUT_OPEN_CHANNEL,
+  DEPOSIT_CHANNEL_VALUE_TOO_LOW,
 };
 
 const Callbacks = () => {

--- a/test/store/actions/deposit.test.js
+++ b/test/store/actions/deposit.test.js
@@ -1,0 +1,124 @@
+import * as depositScripts from "../../../src/scripts/deposit";
+import * as signatureResolver from "../../../src/utils/handlerResolver";
+import callbacks, { CALLBACKS } from "../../../src/utils/callbacks";
+import client from "../../../src/apiRest";
+import * as depositActions from "../../../src/store/actions/deposit";
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import * as stateFunctions from "../../../src/store/functions/state";
+import { CHANNEL_OPENED } from "../../../src/config/channelStates";
+import { NEW_DEPOSIT } from "../../../src/store/actions/types";
+
+// Mock store
+const lh = {
+  storage: { saveLuminoData: jest.fn() },
+};
+const middlewares = [thunk.withExtraArgument(lh)];
+const mockStore = configureMockStore(middlewares);
+
+const address = "0x920984391853d81CCeeC41AdB48a45D40594A0ec";
+const randomPartner = "0xB59ef6015d0e5d46AC9515dcd3f8b928Bb7F87d3";
+const randomAddress = "0xe3066B701f4a3eC8EcAA6D63ADc45180e5022bA3";
+
+describe("test close deposit action", () => {
+  const spyDepositApprovalTX = jest.spyOn(depositScripts, "createApprovalTx");
+  const spyDepositTX = jest.spyOn(depositScripts, "createDepositTx");
+  const spyResolver = jest.spyOn(signatureResolver, "default");
+  const spyCallbacks = jest.spyOn(callbacks, "trigger");
+  const spyGetState = jest.spyOn(stateFunctions, "getState");
+  const channelKey = `1-${randomAddress}`;
+  const state = {
+    client: {
+      address,
+    },
+    channelReducer: {
+      [channelKey]: {
+        partner_address: randomPartner,
+        creator_address: address,
+        token_address: randomAddress,
+        offChainBalance: "1000",
+        total_deposit: "10000",
+      },
+    },
+  };
+
+  const params = {
+    address,
+    partner: randomPartner,
+    tokenAddress: randomAddress,
+    channelId: 1,
+    amount: "1000000000",
+  };
+
+  afterEach(() => {
+    spyDepositApprovalTX.mockReset();
+    spyDepositTX.mockReset();
+    spyResolver.mockReset();
+    spyCallbacks.mockReset();
+    spyGetState.mockReset();
+  });
+
+  test("should call callback when amount to deposit is not enough", async () => {
+    const store = mockStore(state);
+
+    // Spies
+    spyGetState.mockImplementation(() => store.getState());
+
+    const paramsFailDeposit = { ...params, amount: "9000" };
+
+    await store.dispatch(depositActions.createDeposit(paramsFailDeposit));
+
+    const expectedFirstArg = {
+      currentDeposit: "10000",
+      valueDifference: "0",
+      amount: "10000",
+    };
+    const expectSecondArg = new Error(
+      `The current deposit is ${expectedFirstArg.currentDeposit} and the final amount is ${expectedFirstArg.amount}, the amount must be greater than the deposit, difference ${expectedFirstArg.valueDifference}`
+    );
+    expect(spyCallbacks).toHaveBeenCalledWith(
+      CALLBACKS.DEPOSIT_CHANNEL_VALUE_TOO_LOW,
+      expectedFirstArg,
+      expectSecondArg
+    );
+  });
+
+  test("should perform a proper deposit", async () => {
+    const store = mockStore(state);
+
+    // Spies
+    spyGetState.mockImplementation(() => store.getState());
+    spyDepositApprovalTX.mockImplementation(() => "0x123");
+    spyDepositTX.mockImplementation(() => "0x123456");
+    spyResolver.mockResolvedValue("0x123456");
+    const resolvedMock = {
+      data: { channel_identifier: 1, total_deposit: "1000001000" },
+    };
+    client.patch.mockResolvedValue(resolvedMock);
+
+    await store.dispatch(depositActions.createDeposit(params));
+
+    expect(spyCallbacks).toBeCalledTimes(1);
+    const actionData = {
+      partner_address: randomPartner,
+      creator_address: address,
+      token_address: randomAddress,
+      total_deposit: "10000",
+      offChainBalance: "1000",
+      amount: "1000001000",
+    };
+    expect(spyCallbacks).toHaveBeenNthCalledWith(
+      1,
+      CALLBACKS.REQUEST_DEPOSIT_CHANNEL,
+      actionData
+    );
+
+    const actions = store.getActions();
+    expect(actions.length).toBe(1);
+    const expectedAction = {
+      type: NEW_DEPOSIT,
+      channel: { ...resolvedMock.data, sdk_status: CHANNEL_OPENED },
+    };
+    expect(actions[0]).toStrictEqual(expectedAction);
+  });
+});


### PR DESCRIPTION
Due to behaviour differences and user experience, deposits should be done accumulatively, instead of trying to set X value.

Due to this now we set the deposit as offChainBalance + newAmount.

- If the new amount to be the total deposit is equal or lower than the total deposit, it will fail
- In case of the aforementioned failure,an specific callback was designed
- In other cases it will pass as usual
- The deposit tests were missing, I added them
- The case of the insufficient deposit was added to the tests as well
- We have a 100% coverage in the deposit file now.

