### PR TITLE
Fix mutation on redux action RIFEX-179

### DIFF
--- a/src/store/reducers/channelReducer.js
+++ b/src/store/reducers/channelReducer.js
@@ -262,7 +262,10 @@ const channel = (state = initialState, action) => {
     case SET_CHANNEL_AWAITING_CLOSE: {
       const channelKey = getChannelKey(action.channel); 
       const newState = { ...state };
-      newState[channelKey].sdk_status = CHANNEL_WAITING_FOR_CLOSE;
+      newState[channelKey] = {
+        ...newState[channelKey],
+        sdk_status: CHANNEL_WAITING_FOR_CLOSE,
+      };
       return newState;
     }
     default:


### PR DESCRIPTION
When making RIFEX-179 a mutation was left in the redux reducer.

It is not very harmful per se, but we really want to avoid them, so we don't have issues with stalled data.