### PR TITLE
Bugfix/rifex 195 - Remove improper trigger of open channel

### DIFF
--- a/src/store/sagas/index.js
+++ b/src/store/sagas/index.js
@@ -15,7 +15,6 @@ import {
   OPEN_CHANNEL_VOTE,
   CLOSE_CHANNEL_VOTE,
   SET_PAYMENT_FAILED,
-  OPEN_CHANNEL,
 } from "../actions/types";
 import { saveLuminoData } from "../actions/storage";
 import { Lumino } from "../../index";
@@ -230,16 +229,11 @@ export function* workClientOnboardingSuccess({ address }) {
   );
 }
 
-export function* workOpenChannel({ channel }) {
-  return yield Lumino.callbacks.trigger(CALLBACKS.OPEN_CHANNEL, channel);
-}
-
 export default function* rootSaga() {
   yield takeEvery(MESSAGE_POLLING, workMessagePolling);
   yield takeEvery(CREATE_PAYMENT, workCreatePayment);
   yield takeEvery(SET_PAYMENT_COMPLETE, workPaymentComplete);
   yield takeEvery(RECEIVED_PAYMENT, workReceivedPayment);
-  yield takeEvery(OPEN_CHANNEL, workOpenChannel);
   yield takeEvery(NEW_DEPOSIT, workDepositChannel);
   yield takeEvery(NOTIFICATIONS_POLLING, workNotificationPolling);
   yield takeEvery(REQUEST_CLIENT_ONBOARDING, workRequestClientOnboarding);


### PR DESCRIPTION
This one is my bad, I added code to trigger the open channel callback when the action is dispatched.

But this could happen, even if the channel was not opened (ex. notifiers not responding)

This fixes the issue by deleting such code.