### PR TITLE
RLP-735 Fix second and onwards deposit on channel

### DIFF
--- a/src/store/actions/deposit.js
+++ b/src/store/actions/deposit.js
@@ -42,6 +42,7 @@ export const createDeposit = params => async (dispatch, getState, lh) => {
 
     const txParams = {
       ...params,
+      amount,
       address: clientAddress,
     };
     const unsignedApprovalTx = await createApprovalTx(txParams);


### PR DESCRIPTION
This fixes a bug after solving the issue with making incremental deposits.

The issue was that the signed TX had the old amount (the one passed by the user) and not the final amount (the proper new amount which was the incremental one)

This pr fixes the txParams so the signed tx is correct.