### PR TITLE
RLP-736 Fix LT validation with channel opened from partner

### DIFF
--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -27,14 +27,13 @@ import {
   validateLockedTransfer,
   signatureRecover,
 } from "../../utils/validators";
-import { getChannelsState } from "../functions";
 import {
   MessageType,
   PAYMENT_EXPIRED,
   PAYMENT_SUCCESSFUL,
 } from "../../config/messagesConstants";
 import { saveLuminoData } from "./storage";
-import { getLatestChannelByPartnerAndToken } from "../functions/channels";
+import { getLatestChannelByPartnerAndToken, getChannelByIdAndToken } from "../functions/channels";
 import {
   searchTokenDataInChannels,
   getTokenAddressByTokenNetwork,
@@ -117,9 +116,14 @@ export const createPayment = params => async (dispatch, getState, lh) => {
     const dataToSign = getDataToSignForLockedTransfer(messageWithHash);
 
     signature = await resolver(dataToSign, lh, true);
-
-    const channels = getChannelsState();
-    const valid = validateLockedTransfer(message, requestBody, channels);
+    const chId = message.channel_identifier;
+    const tokenAddId = getAddress(message.token);
+    const channelFromStore = getChannelByIdAndToken(chId, tokenAddId);
+    const valid = validateLockedTransfer(
+      message,
+      requestBody,
+      channelFromStore
+    );
     if (valid !== true) throw valid;
     const dataToPut = {
       payment_id: payment_id,

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -27,7 +27,7 @@ const throwChannelNotFoundOrNotOpened = partner =>
  * Validates that the parameters received in the LT from the hub are reasonable within what we provided to it.
  * It checks for: Partner, Amount, Token, Address and Signature
  */
-export const validateLockedTransfer = (message, requestBody, channels = {}) => {
+export const validateLockedTransfer = (message, requestBody, channel = {}) => {
   const { getAddress } = ethers.utils;
   const hasSamePartner =
     getAddress(message.target) === requestBody.partner_address;
@@ -38,10 +38,7 @@ export const validateLockedTransfer = (message, requestBody, channels = {}) => {
   const hasSameTokenAddress =
     getAddress(message.token) === requestBody.token_address;
   if (!hasSameTokenAddress) return throwGenericLockedTransfer("Token Address");
-  const channelId = `${message.channel_identifier}-${getAddress(
-    message.token
-  )}`;
-  const hasChannelAndIsOpened = channels[channelId] === CHANNEL_OPENED;
+  const hasChannelAndIsOpened = channel.sdk_status === CHANNEL_OPENED;
   if (!hasChannelAndIsOpened)
     return throwChannelNotFoundOrNotOpened(message.partner_address);
 


### PR DESCRIPTION
This issue was due to a mistake in the usage of the channelState reducer (which I believe should be deprecated.

The error was

"err The Received Locked Transfer specified a channel with the partner: undefined, which is closed or does not exist"

Which happens when checking that the channel exists and is opened, the reducer didn't have that info, but the channel reducer did.

Changing how the validations receives the data (now it receives the channel) should suffice.