### PR TITLE
RLP-741 Fix closeChannel notifier response processing and failing tests

### DIFF
--- a/src/store/actions/notifier.js
+++ b/src/store/actions/notifier.js
@@ -166,7 +166,7 @@ const requestForCloseChannel = async data => {
     const endpoint = "subscribeToCloseChannel";
     const resClose = await notifierOperations.post(endpoint, null, reqConfig);
 
-    return prepareSubscribeActions(resClose.response, url);
+    return prepareSubscribeActions(resClose, url);
   } catch (error) {
     if (error.response && error.response.data)
       return prepareSubscribeActions(error.response, url);

--- a/test/store/actions/payment.test.js
+++ b/test/store/actions/payment.test.js
@@ -57,6 +57,7 @@ describe("test payment actions", () => {
         channel_identifier: 1,
         token_address: randomAddress,
         offChainBalance: "10000000000000",
+        sdk_status: CHANNEL_OPENED
       },
     },
     channelStates: {

--- a/test/utils/validators.test.js
+++ b/test/utils/validators.test.js
@@ -25,9 +25,13 @@ describe("Test validators and their good / bad cases", () => {
   };
 
   test("validateLockedTransfer should return true for a correct one", async () => {
-    const channelKey = `1-${randomAddress}`;
-    const channels = {
-      [channelKey]: CHANNEL_OPENED,
+    const channel = {
+      partner_address: randomPartner,
+      creator_address: address,
+      channel_identifier: 1,
+      token_address: randomAddress,
+      offChainBalance: "10000000000000",
+      sdk_status: CHANNEL_OPENED,
     };
     const LT = {
       target: randomPartner,
@@ -43,7 +47,7 @@ describe("Test validators and their good / bad cases", () => {
       amount: "10000000000000000000000",
       token_address: randomAddress,
     };
-    const result = validateLockedTransfer(LT, ourSentData, channels);
+    const result = validateLockedTransfer(LT, ourSentData, channel);
     expect(result).toBe(true);
   });
 


### PR DESCRIPTION
This PR aims to solve RLP-741.

Due to bad programming, the response of the close channel request for new topics on the notifier, was made successfully, but the data was not properly passed, so the function that processed the topics was getting and undefined value.

Also, from previous PRs, a couple of tests were failing, so I fixed them so they would pass again.

- Fixed failing tests
- Pass the proper response data in the processing chain of the notifier actions