### PR TITLE
RIFEX-238 Fix missing topics on wallet reload/changed address

### DIFF
--- a/src/store/reducers/notifierReducer.js
+++ b/src/store/reducers/notifierReducer.js
@@ -28,21 +28,41 @@ const patchNewTopic = (state, action) => {
   return newTopic;
 };
 
+const mergeNewNotifier = (action, state) => {
+  const { notifierUrl, notifierApiKey } = action;
+
+  // If the notifier exists, just merge it
+  // DO NOT OVERRIDE TOPICS, just the api key
+  if (state.notifiers[notifierUrl])
+    return {
+      ...state,
+      notifiers: {
+        ...state.notifiers,
+        [notifierUrl]: {
+          ...state.notifiers[notifierUrl],
+          apiKey: notifierApiKey,
+        },
+      },
+    };
+
+  // If it doesn't we add it
+  return {
+    ...state,
+    notifiers: {
+      ...state.notifiers,
+      [notifierUrl]: {
+        apiKey: notifierApiKey,
+        topics: {},
+        fromNotificationId: 0,
+      },
+    },
+  };
+};
+
 const notifierReducer = (state = initialState, action) => {
   switch (action.type) {
     case NEW_NOTIFIER: {
-      const newNotifier = {
-        ...state,
-        notifiers: {
-          ...state.notifiers,
-          [action.notifierUrl]: {
-            apiKey: action.notifierApiKey,
-            topics: {},
-            fromNotificationId: 0,
-          },
-        },
-      };
-      return newNotifier;
+      return mergeNewNotifier(action, state);
     }
     case SET_LAST_NOTIFICATION_ID: {
       const { ids } = action;


### PR DESCRIPTION
This issue was making us losing topics when we switched accounts or changed our wallet address.

This was due to the concept that if a notifier is subscribed to, it should have no topics.

I added a check logic, so instead of overwriting an existing notifier with it topics for an empty object of topics, it should merge it instead.

This should fix any issue when re-subscribing to a notifier and losing all the stored topics on it.

Should solve RIFEX-238 integration