### PR TITLE
RIFEX-254 Fix non closing BP signature method and test

### DIFF
--- a/src/config/messagesConstants.js
+++ b/src/config/messagesConstants.js
@@ -45,7 +45,7 @@ export const MessageKeyForOrder = {
 
 export const MessageNumPad = {
   [MessageType.PROCESSED]: 0,
-  UPDATE_BALANCE_PROOF: 2,
+  UPDATE_BALANCE_PROOF: 4,
   [MessageType.SECRET_REQUEST]: 3,
   [MessageType.BALANCE_PROOF]: 4,
   [MessageType.LOCKED_TRANSFER]: 7,

--- a/test/sign/index.test.js
+++ b/test/sign/index.test.js
@@ -129,9 +129,9 @@ test("should sign and recover from NonClosingBP", async () => {
   const recoveredAddress = ethers.utils.verifyMessage(dataToSign, signature);
 
   expect(recoveredAddress).toBe(address);
-  // const pythonSignature =
-  //   "94215efdcd1393033d2e0c714a54335148b5f5ee15532728a5a29dc2da2137075898ab2415e41744753427a5c71964a430df3dbc000a1245cfb97632cdaaa4ed1c";
-  // expect(signature.slice(2)).toBe(pythonSignature);
+  const pythonSignature =
+    "cae1494fe9c978eb8eb1a7ed94e1959f731967f19423d76f3cbea39c3c0100040a7eb4dd150352fe395fb51e3c83637df24d1695a5123429120834a45635c4ea1c";
+  expect(signature.slice(2)).toBe(pythonSignature);
 });
 
 test("should sign and recover from Delivered", async () => {


### PR DESCRIPTION
The non closing BP test was commented since the test in the node was not working properly.

As such, the code was fragile, and our checks were not enough to prevent bugs (such as an invalid recover)

The padding in the message packing before the signature was incorrect, so I corrected it and made sure that the test value was the proper ones.

- Now the test completely passes
- The Non Closing BP method should be working and don't cause any more issues