### PR TITLE
RLP-724 Lock Expired Fixes

### DIFF
--- a/src/store/functions/payments.js
+++ b/src/store/functions/payments.js
@@ -89,10 +89,7 @@ export const getSenderAndReceiver = (payment, msgOrder = 0) => {
         receiver = customReceiverOnOrder[msgOrder];
     }
     // Failed cases
-    if (failureReason) {
-      const isRefunded = failureReason === REFUND_TRANSFER;
-      if (isRefunded) receiver = mediator;
-    }
+    if (failureReason) receiver = mediator;
   }
   try {
     return {

--- a/src/store/reducers/paymentsReducer.js
+++ b/src/store/reducers/paymentsReducer.js
@@ -11,6 +11,7 @@ import {
   STORE_REFUND_TRANSFER,
   ADD_REFUNDED_PAYMENT_MESSAGE,
 } from "../actions/types";
+import { PENDING_PAYMENT } from "../../config/paymentConstants";
 
 const initialState = {
   pending: {},
@@ -104,7 +105,10 @@ const paymentsReducer = (state = initialState, action) => {
       const newState = cloneState(state);
       newState.failed[paymentId] = state[paymentStateL][paymentId];
       newState.failed[paymentId].failureReason = reason;
-      delete newState[paymentStateL][paymentId];
+      // Only remove payment from pending state
+      // Refund => Expired states must not delete it
+      if (paymentState === PENDING_PAYMENT)
+        delete newState[paymentStateL][paymentId];
       return newState;
     }
     case STORE_REFUND_TRANSFER: {
@@ -144,10 +148,10 @@ const paymentsReducer = (state = initialState, action) => {
     case ADD_REFUNDED_PAYMENT_MESSAGE: {
       const { messageOrder, message } = action;
       const newState = cloneState(state);
-      if(!newState.failed[paymentId].refund) {
+      if (!newState.failed[paymentId].refund) {
         newState.failed[paymentId].refund = {
           messages: {},
-          message_order: 0
+          message_order: 0,
         };
       }
       newState.failed[paymentId].refund.messages[messageOrder] = message;

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -10,6 +10,7 @@ import {
   PENDING_PAYMENT,
   EXPIRED,
   REFUND_TRANSFER,
+  FAILED_PAYMENT,
 } from "../config/paymentConstants";
 import {
   getPendingPaymentById,
@@ -197,11 +198,8 @@ const manageLockExpired = (msgData, payment) => {
 
   const paymentAux = getPayment(payment_id);
   if (paymentAux.expiration && paymentAux.expiration.messages[1]) return null;
-  if (!paymentAux.failureReason)
-    dispatch(
-      setPaymentFailed(payment_id, PENDING_PAYMENT, FAILURE_REASONS.EXPIRED)
-    );
-
+  const paymentState = paymentAux.failureReason ? FAILED_PAYMENT : PENDING_PAYMENT;
+  dispatch(setPaymentFailed(payment_id, paymentState, FAILURE_REASONS.EXPIRED));
   const dataForPut = {
     ...paymentAux,
     signature: message.signature,


### PR DESCRIPTION
When mediated payments that had a refund generated a LE, the SDK was not properly handling these cases.

- The logic was fixed to accomodate the re-fail of the payment
- The transition is now ok
- The LE messages are managed properly
