### PR TITLE
RIFEX-282 Do not open channels with yourself

### DIFF
--- a/test/store/actions/open.test.js
+++ b/test/store/actions/open.test.js
@@ -161,4 +161,27 @@ describe("test open channel action", () => {
       "Generic Error"
     );
   });
+
+  test("should trigger error callback on opening channel with yourself", async () => {
+    const store = mockStore(state);
+
+    await store.dispatch(
+      openActions.openChannel({
+        partner: address,
+        tokenAddress: randomAddress,
+      })
+    );
+
+    expect(spyCallbacks).toBeCalledTimes(1);
+    const expectedError = new Error("Can't create channel with yourself");
+    const expectedChannel = {
+      partner: address,
+    };
+    expect(spyCallbacks).toHaveBeenNthCalledWith(
+      1,
+      CALLBACKS.FAILED_OPEN_CHANNEL,
+      expectedChannel,
+      expectedError
+    );
+  });
 });


### PR DESCRIPTION
This pr aims to add an extra check when opening a channel, preventing the user from trying to open a channel with themselves.

- The check was added
- Some code was moved so it can use the callback
- A test was added for this behaviour
