### PR TITLE
RLP-764 Send additional metadata in proper request

### DIFF
--- a/src/store/actions/payment.js
+++ b/src/store/actions/payment.js
@@ -104,14 +104,6 @@ export const createPayment = params => async (dispatch, getState, lh) => {
       secrethash,
     };
 
-    // For refunded payments
-    if (previousSecretHash) {
-      requestBody.prev_secrethash = previousSecretHash;
-      requestBody.additional_metadata = {
-        previous_hash: previousSecretHash,
-      };
-    }
-
     const urlCreate = "payments_light/create";
     const res = await client.post(urlCreate, requestBody);
     const {
@@ -149,6 +141,13 @@ export const createPayment = params => async (dispatch, getState, lh) => {
         signature,
       },
     };
+
+    // For refunded payments
+    if (previousSecretHash) {
+      dataToPut.additional_metadata = {
+        previous_hash: previousSecretHash,
+      };
+    }
 
     const urlPut = "payments_light";
     // Send signed LT to HUB


### PR DESCRIPTION
Due to an error, the LC was sending the additional_metadata to the hub in the create operation of a payment, and not when the payment LT was being sent.

This PR includes the next:

- The additional_metadata is now sent with the LT (message number 1) of the protocol if applicable