### PR TITLE
RLP-806 Allow the SDK to work without notifiers

### DIFF
--- a/src/Lumino/index.js
+++ b/src/Lumino/index.js
@@ -22,7 +22,7 @@ const Lumino = () => {
     apiKey: "",
     notifierEndPoint: NOTIFIER_BASE_URL,
     registryAddress: AddressZero,
-    useNotifiers: false
+    useNotifiers: false,
   };
 
   /**

--- a/src/Lumino/index.js
+++ b/src/Lumino/index.js
@@ -22,6 +22,7 @@ const Lumino = () => {
     apiKey: "",
     notifierEndPoint: NOTIFIER_BASE_URL,
     registryAddress: AddressZero,
+    useNotifiers: false
   };
 
   /**

--- a/src/store/actions/close.js
+++ b/src/store/actions/close.js
@@ -12,6 +12,7 @@ import { CHANNEL_WAITING_FOR_CLOSE } from "../../config/channelStates";
 import { Lumino } from "../..";
 import { CALLBACKS } from "../../utils/callbacks";
 import { getChannelByIdAndToken } from "../functions";
+import { getNumberOfNotifiers } from "../functions/notifiers";
 
 /**
  * Close a channel.
@@ -53,10 +54,14 @@ export const closeChannel = params => async (dispatch, getState, lh) => {
       channelAwaitingClose
     );
     const res = await client.patch(url, { ...requestBody });
-
+    const numberOfNotifiers = getNumberOfNotifiers().length;
     dispatch({
       type: SET_CHANNEL_CLOSED,
-      channel: { ...res.data, sdk_status: CHANNEL_WAITING_FOR_CLOSE },
+      channel: {
+        ...res.data,
+        sdk_status: CHANNEL_WAITING_FOR_CLOSE,
+        numberOfNotifiers,
+      },
     });
     const allData = getState();
     return await lh.storage.saveLuminoData(allData);

--- a/src/store/actions/close.js
+++ b/src/store/actions/close.js
@@ -60,8 +60,8 @@ export const closeChannel = params => async (dispatch, getState, lh) => {
       channel: {
         ...res.data,
         sdk_status: CHANNEL_WAITING_FOR_CLOSE,
-        numberOfNotifiers,
       },
+      numberOfNotifiers,
     });
     const allData = getState();
     return await lh.storage.saveLuminoData(allData);

--- a/src/store/reducers/channelReducer.js
+++ b/src/store/reducers/channelReducer.js
@@ -170,7 +170,7 @@ const channel = (state = initialState, action) => {
       let newChannel = createChannel(action.channel, true);
       newChannel = checkIfChannelCanBeOpened(newChannel, numberOfNotifiers);
       let newState = { ...state };
-      
+
       // Can we remove a temporary channel?
       if (newChannel.canRemoveTemporalChannel)
         newState = removeTemporaryChannel(newChannel, newState);

--- a/src/store/reducers/channelReducer.js
+++ b/src/store/reducers/channelReducer.js
@@ -20,6 +20,7 @@ import {
   CHANNEL_SETTLED,
 } from "../../config/channelStates";
 import { VOTE_TYPE } from "../../config/notifierConstants";
+import { Lumino } from "../..";
 
 const initialState = {};
 
@@ -106,6 +107,7 @@ const addVote = (channel, vote, voteType) => {
 const checkIfChannelCanBeOpened = (channel, numberOfNotifiers) => {
   // If we have the half + 1 votes of approval, we open the channel
   // Also we need the hub to have answered the request and we opened the channel
+  const { useNotifiers } = Lumino.getConfig();
   const openVotesQuantity = Object.values(channel.votes.open).filter(v => v)
     .length;
 
@@ -114,7 +116,7 @@ const checkIfChannelCanBeOpened = (channel, numberOfNotifiers) => {
   const canBeOpened = !openedByUser || (openedByUser && hubAnswered);
 
   // Needed votes to be opened
-  const neededVotes = Math.ceil(numberOfNotifiers / 2);
+  const neededVotes = useNotifiers ? Math.ceil(numberOfNotifiers / 2) : 0;
 
   if (openVotesQuantity >= neededVotes && canBeOpened) {
     channel.sdk_status = SDK_CHANNEL_STATUS.CHANNEL_OPENED;

--- a/src/store/reducers/channelReducer.js
+++ b/src/store/reducers/channelReducer.js
@@ -201,16 +201,22 @@ const channel = (state = initialState, action) => {
     }
 
     case SET_CHANNEL_CLOSED: {
-      const cChannelKey = getChannelKey(action.channel);
+      const chKey = getChannelKey(action.channel);
 
-      const channelsModified = {
+      const newState = {
         ...state,
-        [cChannelKey]: {
-          ...state[cChannelKey],
+        [chKey]: {
+          ...state[chKey],
           ...action.channel,
         },
       };
-      return channelsModified;
+      const { numberOfNotifiers } = action;
+      newState[chKey] = checkIfChannelCanBeClosed(
+        newState[chKey],
+        numberOfNotifiers
+      );
+
+      return newState;
     }
 
     case NEW_DEPOSIT: {

--- a/test/store/actions/close.test.js
+++ b/test/store/actions/close.test.js
@@ -38,6 +38,7 @@ describe("test close channel action", () => {
         channel_identifier: 1,
       },
     },
+    notifier: { notifiers: {} },
   };
 
   const params = {
@@ -92,6 +93,7 @@ describe("test close channel action", () => {
         channel_identifier: 1,
         sdk_status: "CHANNEL_WAITING_FOR_CLOSE",
       },
+      numberOfNotifiers: 0,
       type: SET_CHANNEL_CLOSED,
     };
 


### PR DESCRIPTION
This PR allows the SDK to work without notifiers

Features 📚

- Notifiers usage is now opt-in
- A new boolean in the config params is required to enable them
- If a channel is open/closed and notifiers usage is disabled, they will immediately transition to the appropiate state
  - This means that they need no votes in order to be considered opened/closed


Note ❗️

- If notifiers are not registered, the SDK can not properly transition a channel when a partner creates it or closes it

Solves RLP-806