### PR TITLE
RLP-819 Send message identifier with Settlement TX

### DIFF
--- a/src/store/actions/settle.js
+++ b/src/store/actions/settle.js
@@ -8,7 +8,7 @@ import { saveLuminoData } from "./storage";
 import { SET_CHANNEL_SETTLED, SET_IS_SETTLING } from "./types";
 
 export const settleChannel = data => async (dispatch, getState, lh) => {
-  const { txParams } = data;
+  const { txParams, internal_message_identifier } = data;
   const unsignedTx = await createSettleTx(txParams);
   const signedTx = await resolver(unsignedTx, lh);
   const { channelIdentifier } = txParams;
@@ -16,6 +16,7 @@ export const settleChannel = data => async (dispatch, getState, lh) => {
   const requestBody = {
     signed_settle_tx: signedTx,
     channel_identifier: channelIdentifier,
+    internal_message_identifier,
   };
   const { tokenNetworkAddress } = txParams;
   const tokenAddress = getTokenAddressByTokenNetwork(tokenNetworkAddress);

--- a/src/store/epics/index.js
+++ b/src/store/epics/index.js
@@ -22,7 +22,6 @@ import {
 
 export const paymentsMonitoredEpic = action$ => {
   const stopPolling$ = action$.pipe(ofType(MESSAGE_POLLING_STOP));
-  // TODO: Change conditionally the timer
   return action$.pipe(
     ofType(MESSAGE_POLLING_START),
     switchMap(() =>
@@ -49,7 +48,6 @@ export const paymentsMonitoredEpic = action$ => {
 
 export const notificationsMonitoredEpic = action$ => {
   const stopPolling$ = action$.pipe(ofType(STOP_NOTIFICATIONS_POLLING));
-  // TODO: Change conditionally the timer within other networks
   return action$.pipe(
     ofType(START_NOTIFICATIONS_POLLING),
     switchMap(() =>

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -133,7 +133,7 @@ const manageNonPaymentMessages = (messages = []) => {
 };
 
 const manageSettlementRequired = async msg => {
-  const { message } = msg;
+  const { message, internal_msg_identifier } = msg;
   const { channel_identifier, channel_network_identifier } = message;
   const tokenNetwork = chkSum(channel_network_identifier);
   const token = getTokenAddressByTokenNetwork(tokenNetwork);
@@ -168,6 +168,7 @@ const manageSettlementRequired = async msg => {
   const { dispatch } = store;
   const settleData = {
     txParams,
+    internal_msg_identifier,
     creatorAddress: chkSum(creatorAddress),
     partnerAddress: chkSum(partnerAddress),
   };

--- a/src/utils/pack.js
+++ b/src/utils/pack.js
@@ -71,8 +71,6 @@ export const createMessageHash = (data, type = MessageType.BALANCE_PROOF) => {
   return ethers.utils.keccak256(messageHashUnhashed);
 };
 
-// TODO: Separate the methods and document their uses according to messages
-
 export const getDataToSignForLockedTransfer = message => {
   const messageHashArray = ethers.utils.concat([
     hexEncode(MessageNumPad[MessageType.LOCKED_TRANSFER], 1), // CMDID, as in the python implementation


### PR DESCRIPTION
This PR aims to make a small change in the SDK to prevent duplicated processing of settlement messages.

Features 📚

- Now the settlement TX is sent alongside a message identifier
- Some old TODO's cleanup 🧹