### PR TITLE
RLP-831 Trigger settlement callback

### DIFF
--- a/src/store/actions/settle.js
+++ b/src/store/actions/settle.js
@@ -3,7 +3,7 @@ import client from "../../apiRest";
 import { createSettleTx } from "../../scripts/settle";
 import { CALLBACKS } from "../../utils/callbacks";
 import resolver from "../../utils/handlerResolver";
-import { getState } from "../functions";
+import { getChannelByIdAndToken } from "../functions";
 import { getTokenAddressByTokenNetwork } from "../functions/tokens";
 import { saveLuminoData } from "./storage";
 import { SET_CHANNEL_SETTLED, SET_IS_SETTLING } from "./types";
@@ -31,8 +31,7 @@ export const settleChannel = data => async (dispatch, _, lh) => {
     await client.post(url, { ...requestBody });
 
     dispatch(setChannelSettled(dispatchData));
-    const channelKey = `${channelIdentifier}-${tokenAddress}`;
-    const channel = getState().channelReducer[channelKey];
+    const channel = getChannelByIdAndToken(channelIdentifier, tokenAddress);
     Lumino.callbacks.trigger(CALLBACKS.CHANNEL_HAS_SETTLED, channel);
     dispatch(saveLuminoData());
   } catch (error) {
@@ -48,8 +47,7 @@ export const settleChannel = data => async (dispatch, _, lh) => {
     );
     if (wasSettled || wasUnlocked) {
       dispatch(setChannelSettled(dispatchData));
-      const channelKey = `${channelIdentifier}-${tokenAddress}`;
-      const channel = getState().channelReducer[channelKey];
+      const channel = getChannelByIdAndToken(channelIdentifier, tokenAddress);
       Lumino.callbacks.trigger(CALLBACKS.CHANNEL_HAS_SETTLED, channel);
       return dispatch(saveLuminoData());
     }


### PR DESCRIPTION
This PR aims to include a missing case for the settlement callback

New features 📚

- The callback is triggered when a settlement is successful
- The callback is also triggered when a settlement fails because a channel was already settled
- Some code was simplified to use abstracted functions (getChannelByIdAndToken)