### PR TITLE
RLP-820 Pass internal_msg_identifier in register secret

### DIFF
--- a/src/store/actions/secret.js
+++ b/src/store/actions/secret.js
@@ -11,7 +11,12 @@ import {
 } from "./types";
 
 export const registerSecret = data => async (dispatch, getState, lh) => {
-  const { secret, secretRegistryAddress, paymentId } = data;
+  const {
+    secret,
+    secretRegistryAddress,
+    paymentId,
+    internal_message_identifier,
+  } = data;
   const { address } = Lumino.getConfig();
   const txParams = { secret, secretRegistryAddress, address };
   const unsignedTx = await createRegisterSecretTx(txParams);
@@ -19,7 +24,7 @@ export const registerSecret = data => async (dispatch, getState, lh) => {
   const url = "payments_light/register_onchain_secret";
   try {
     dispatch(registeringOnChainSecret(true, paymentId));
-    const body = { signed_tx: signedTx };
+    const body = { signed_tx: signedTx, internal_message_identifier };
     await client.post(url, body, { transformResponse: null });
     dispatch(registeredOnChainSecret(paymentId));
     const payment = getPaymentByIdAndState("pending", paymentId);

--- a/src/store/actions/secret.js
+++ b/src/store/actions/secret.js
@@ -15,7 +15,7 @@ export const registerSecret = data => async (dispatch, getState, lh) => {
     secret,
     secretRegistryAddress,
     paymentId,
-    internal_message_identifier,
+    internal_msg_identifier,
   } = data;
   const { address } = Lumino.getConfig();
   const txParams = { secret, secretRegistryAddress, address };
@@ -24,7 +24,7 @@ export const registerSecret = data => async (dispatch, getState, lh) => {
   const url = "payments_light/register_onchain_secret";
   try {
     dispatch(registeringOnChainSecret(true, paymentId));
-    const body = { signed_tx: signedTx, internal_message_identifier };
+    const body = { signed_tx: signedTx, internal_msg_identifier };
     await client.post(url, body, { transformResponse: null });
     dispatch(registeredOnChainSecret(paymentId));
     const payment = getPaymentByIdAndState("pending", paymentId);

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -99,7 +99,7 @@ const getPayment = paymentId => {
 const manageNonPaymentMessages = (messages = []) => {
   const messagesToProcessLast = [];
 
-  messages.forEach(({ message_content: msg, internal_message_identifier }) => {
+  messages.forEach(({ message_content: msg, internal_msg_identifier }) => {
     const { payment_id } = msg;
     let payment = getPayment(payment_id);
 
@@ -123,7 +123,7 @@ const manageNonPaymentMessages = (messages = []) => {
       case MessageType.REQUEST_REGISTER_SECRET: {
         return manageRequestRegisterSecret({
           ...msg,
-          internal_message_identifier,
+          internal_msg_identifier,
         });
       }
       case MessageType.UNLOCK_REQUEST: {
@@ -257,7 +257,7 @@ const managePaymentMessages = (messages = []) => {
 };
 
 const manageRequestRegisterSecret = data => {
-  const { payment_id, internal_message_identifier } = data;
+  const { payment_id, internal_msg_identifier } = data;
   const payment = getPayment(payment_id);
   if (!payment) return;
   const { registeringOnChainSecret, registeredOnChainSecret } = payment;
@@ -273,7 +273,7 @@ const manageRequestRegisterSecret = data => {
     secretRegistryAddress: secret_registry_address,
     secret,
     paymentId: payment_id,
-    internal_message_identifier,
+    internal_msg_identifier,
   };
   dispatch(registerSecret(dispatchData));
 };

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -254,7 +254,7 @@ const managePaymentMessages = (messages = []) => {
 };
 
 const manageRequestRegisterSecret = data => {
-  const { payment_id } = data;
+  const { payment_id, internal_message_identifier } = data;
   const payment = getPayment(payment_id);
   if (!payment) return;
   const { registeringOnChainSecret, registeredOnChainSecret } = payment;
@@ -270,6 +270,7 @@ const manageRequestRegisterSecret = data => {
     secretRegistryAddress: secret_registry_address,
     secret,
     paymentId: payment_id,
+    internal_message_identifier,
   };
   dispatch(registerSecret(dispatchData));
 };

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -99,7 +99,7 @@ const getPayment = paymentId => {
 const manageNonPaymentMessages = (messages = []) => {
   const messagesToProcessLast = [];
 
-  messages.forEach(({ message_content: msg }) => {
+  messages.forEach(({ message_content: msg, internal_message_identifier }) => {
     const { payment_id } = msg;
     let payment = getPayment(payment_id);
 
@@ -121,7 +121,10 @@ const manageNonPaymentMessages = (messages = []) => {
         return manageSettlementRequired(msg);
       }
       case MessageType.REQUEST_REGISTER_SECRET: {
-        return manageRequestRegisterSecret(msg);
+        return manageRequestRegisterSecret({
+          ...msg,
+          internal_message_identifier,
+        });
       }
       case MessageType.UNLOCK_REQUEST: {
         return manageUnlockRequest(msg);


### PR DESCRIPTION
This PR aims to include a param in the register secret request, so the HUB can mark the task as processed and will not attempt to send the message afterwards.

New features   📚

- Added a new param called internal_msg_identifier in the register secret request