### PR TITLE
RLP-821 send internal_msg_identifier in unlock request

### DIFF
--- a/src/store/actions/unlock.js
+++ b/src/store/actions/unlock.js
@@ -15,6 +15,7 @@ export const unlockChannel = data => async (dispatch, getState, lh) => {
     channel_identifier,
     receiver,
     sender,
+    internal_message_identifier,
   } = data;
   const tokenNetworkAddress = getTokenNetworkByTokenAddress(tokenAddress);
   const dispatchData = { channel_identifier, token_address: tokenAddress };
@@ -29,7 +30,7 @@ export const unlockChannel = data => async (dispatch, getState, lh) => {
 
   const unsignedTx = await createUnlockTx(txParams);
   const signedTx = await resolver(unsignedTx, lh);
-  const body = { signed_tx: signedTx };
+  const body = { signed_tx: signedTx, internal_message_identifier };
   const url = `payments_light/unlock/${tokenAddress}`;
 
   try {

--- a/src/store/actions/unlock.js
+++ b/src/store/actions/unlock.js
@@ -15,7 +15,7 @@ export const unlockChannel = data => async (dispatch, getState, lh) => {
     channel_identifier,
     receiver,
     sender,
-    internal_message_identifier,
+    internal_msg_identifier,
   } = data;
   const tokenNetworkAddress = getTokenNetworkByTokenAddress(tokenAddress);
   const dispatchData = { channel_identifier, token_address: tokenAddress };
@@ -30,7 +30,7 @@ export const unlockChannel = data => async (dispatch, getState, lh) => {
 
   const unsignedTx = await createUnlockTx(txParams);
   const signedTx = await resolver(unsignedTx, lh);
-  const body = { signed_tx: signedTx, internal_message_identifier };
+  const body = { signed_tx: signedTx, internal_msg_identifier };
   const url = `payments_light/unlock/${tokenAddress}`;
 
   try {

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -99,7 +99,7 @@ const getPayment = paymentId => {
 const manageNonPaymentMessages = (messages = []) => {
   const messagesToProcessLast = [];
 
-  messages.forEach(({ message_content: msg }) => {
+  messages.forEach(({ message_content: msg, internal_message_identifier }) => {
     const { payment_id } = msg;
     let payment = getPayment(payment_id);
 
@@ -124,7 +124,7 @@ const manageNonPaymentMessages = (messages = []) => {
         return manageRequestRegisterSecret(msg);
       }
       case MessageType.UNLOCK_REQUEST: {
-        return manageUnlockRequest(msg);
+        return manageUnlockRequest({ ...msg, internal_message_identifier });
       }
     }
   });
@@ -141,6 +141,7 @@ const manageNonPaymentMessages = (messages = []) => {
 };
 
 const manageUnlockRequest = async msg => {
+  const { internal_message_identifier } = msg;
   const { channel_identifier, token_address } = msg.message;
   const channel = getChannelByIdAndToken(channel_identifier, token_address);
   if (!channel) return;
@@ -148,7 +149,7 @@ const manageUnlockRequest = async msg => {
   if (isUnlocked || isUnlocking) return;
   const store = Store.getStore();
   const { dispatch } = store;
-  dispatch(unlockChannel(msg.message));
+  dispatch(unlockChannel({ ...msg.message, internal_message_identifier }));
 };
 
 const manageSettlementRequired = async msg => {

--- a/src/utils/messageManager.js
+++ b/src/utils/messageManager.js
@@ -99,7 +99,7 @@ const getPayment = paymentId => {
 const manageNonPaymentMessages = (messages = []) => {
   const messagesToProcessLast = [];
 
-  messages.forEach(({ message_content: msg, internal_message_identifier }) => {
+  messages.forEach(({ message_content: msg, internal_msg_identifier }) => {
     const { payment_id } = msg;
     let payment = getPayment(payment_id);
 
@@ -124,7 +124,7 @@ const manageNonPaymentMessages = (messages = []) => {
         return manageRequestRegisterSecret(msg);
       }
       case MessageType.UNLOCK_REQUEST: {
-        return manageUnlockRequest({ ...msg, internal_message_identifier });
+        return manageUnlockRequest({ ...msg, internal_msg_identifier });
       }
     }
   });
@@ -141,7 +141,7 @@ const manageNonPaymentMessages = (messages = []) => {
 };
 
 const manageUnlockRequest = async msg => {
-  const { internal_message_identifier } = msg;
+  const { internal_msg_identifier } = msg;
   const { channel_identifier, token_address } = msg.message;
   const channel = getChannelByIdAndToken(channel_identifier, token_address);
   if (!channel) return;
@@ -149,7 +149,7 @@ const manageUnlockRequest = async msg => {
   if (isUnlocked || isUnlocking) return;
   const store = Store.getStore();
   const { dispatch } = store;
-  dispatch(unlockChannel({ ...msg.message, internal_message_identifier }));
+  dispatch(unlockChannel({ ...msg.message, internal_msg_identifier }));
 };
 
 const manageSettlementRequired = async msg => {


### PR DESCRIPTION
This PR aims to include a param in the unlock request, so the HUB can mark the task as processed and will not attempt to send the message afterwards.

New features   📚

- Added a new param called internal_msg_identifier in the unlock request