### PR TITLE
RLP-774: generalize LC onboarding

### DIFF
--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -29,7 +29,7 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
     const signed_seed_retry = await resolver(seed_retry, lh, true);
     // Prepare a body for the request with all the required data
     const body = {
-      registration_data = {
+      registration_data : {
         address,
         signed_password,
         signed_display_name,

--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -15,7 +15,7 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
   try {
     dispatch(stopAllPolling());
     client.defaults.headers = {};
-    const urlOnboard = "light_clients/matrix/credentials";
+    const urlOnboard = "light_clients/";
     const onboardReq = await client.get(urlOnboard, { params: { address } });
     // We get the data
     const {
@@ -29,17 +29,18 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
     const signed_seed_retry = await resolver(seed_retry, lh, true);
     // Prepare a body for the request with all the required data
     const body = {
-      address,
-      signed_password,
-      signed_display_name,
-      signed_seed_retry,
-      password: password_to_sign,
-      display_name: display_name_to_sign,
-      seed_retry,
+      registration_data = {
+        address,
+        signed_password,
+        signed_display_name,
+        signed_seed_retry,
+        password: password_to_sign,
+        display_name: display_name_to_sign,
+        seed_retry,
+      },
     };
-    const urlPostOnboard = "light_clients/";
     dispatch({ type: REQUEST_CLIENT_ONBOARDING, address });
-    const resOnboard = await client.post(urlPostOnboard, body);
+    const resOnboard = await client.post(urlOnboard, body);
     // We extract the api key, set it as a header and store it on redux
     const { api_key } = resOnboard.data;
 

--- a/src/store/epics/services.js
+++ b/src/store/epics/services.js
@@ -17,7 +17,7 @@ const requestMessages = async (from_message, url) =>
 
 const getTransactionInfo = () => {
   const from_message = getState().client.internal_msg_id || 1;
-  const url = "light_client_messages";
+  const url = "light_clients/messages";
   return from(requestMessages(from_message, url));
 };
 


### PR DESCRIPTION
This PR provides a solution for issue [RLP-774](https://jirainfuy.atlassian.net/browse/RLP-774), which is about generalizing LC onboarding calls to be transport-agnostic, with the goal of eventually adding a RIF Comms implementation.

This PR is also the counterpart to the changes applied in the Lumino repo—see the original PR [here](https://github.com/rsksmart/lumino/pull/140).

### Overview
- LC onboarding data request and LC registration request now share an endpoint—the former uses `HTTP GET`, while the latter uses `HTTP POST`.
- LC registration request now submits all its fields inside a generic dictionary object. This is done so that arbitrary fields can be sent, which paves the way for a RIF Comms LC onboarding implementation that uses the same endpoint.
- LC messages endpoint name is slightly modified for consistency's sake.