### PR TITLE
Feature/rlp 859/rif comms onboarding impl

### DIFF
--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -27,15 +27,19 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
     } = onboardReq.data;
 
     // Check hub current transport implementation
-    let register_body = {}
-    if(transport_mode === "matrix"){
+    let register_body = {};
+    if (transport_mode === "matrix") {
       // Sign the onboarding matrix data
-      const signed_display_name = await resolver(display_name_to_sign, lh, true);
+      const signed_display_name = await resolver(
+        display_name_to_sign,
+        lh,
+        true
+      );
       const signed_password = await resolver(password_to_sign, lh, true);
       const signed_seed_retry = await resolver(seed_retry, lh, true);
       // Prepare a body for the request with all the required data
       register_body = {
-        registration_data : {
+        registration_data: {
           address,
           signed_password,
           signed_display_name,
@@ -45,14 +49,14 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
           seed_retry,
         },
       };
-    }else if(transport_mode === "rif-comms"){
+    } else if (transport_mode === "rif-comms") {
       register_body = {
-        registration_data : {
-          address
-        }
-      }
-    }else{
-      throw new Error("Onboadring error: hub isnt using rif comms nor matrix")
+        registration_data: {
+          address,
+        },
+      };
+    } else {
+      throw new Error("Onboadring error: hub isnt using rif comms nor matrix");
     }
 
     // Register the light client

--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -17,30 +17,47 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
     client.defaults.headers = {};
     const urlOnboard = "light_clients/";
     const onboardReq = await client.get(urlOnboard, { params: { address } });
-    // We get the data
+
+    // Get the onboarding data from the hub
     const {
+      transport_mode,
       display_name_to_sign,
       seed_retry,
       password_to_sign,
     } = onboardReq.data;
-    // Sign it
-    const signed_display_name = await resolver(display_name_to_sign, lh, true);
-    const signed_password = await resolver(password_to_sign, lh, true);
-    const signed_seed_retry = await resolver(seed_retry, lh, true);
-    // Prepare a body for the request with all the required data
-    const body = {
-      registration_data : {
-        address,
-        signed_password,
-        signed_display_name,
-        signed_seed_retry,
-        password: password_to_sign,
-        display_name: display_name_to_sign,
-        seed_retry,
-      },
-    };
+
+    // Check hub current transport implementation
+    let register_body = {}
+    if(transport_mode === "matrix"){
+      // Sign the onboarding matrix data
+      const signed_display_name = await resolver(display_name_to_sign, lh, true);
+      const signed_password = await resolver(password_to_sign, lh, true);
+      const signed_seed_retry = await resolver(seed_retry, lh, true);
+      // Prepare a body for the request with all the required data
+      register_body = {
+        registration_data : {
+          address,
+          signed_password,
+          signed_display_name,
+          signed_seed_retry,
+          password: password_to_sign,
+          display_name: display_name_to_sign,
+          seed_retry,
+        },
+      };
+    }else if(transport_mode === "rif-comms"){
+      register_body = {
+        registration_data : {
+          address
+        }
+      }
+    }else{
+      throw new Error("Onboadring error: hub isnt using rif comms nor matrix")
+    }
+
+    // Register the light client
     dispatch({ type: REQUEST_CLIENT_ONBOARDING, address });
-    const resOnboard = await client.post(urlOnboard, body);
+    const resOnboard = await client.post(urlOnboard, register_body);
     // We extract the api key, set it as a header and store it on redux
     const { api_key } = resOnboard.data;
 

--- a/src/store/actions/onboarding.js
+++ b/src/store/actions/onboarding.js
@@ -20,7 +20,7 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
 
     // Get the onboarding data from the hub
     const {
-      transport_mode,
+      transport_type,
       display_name_to_sign,
       seed_retry,
       password_to_sign,
@@ -28,7 +28,7 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
 
     // Check hub current transport implementation
     let register_body = {};
-    if (transport_mode === "matrix") {
+    if (transport_type === "matrix") {
       // Sign the onboarding matrix data
       const signed_display_name = await resolver(
         display_name_to_sign,
@@ -49,7 +49,7 @@ export const onboardingClient = () => async (dispatch, getState, lh) => {
           seed_retry,
         },
       };
-    } else if (transport_mode === "rif-comms") {
+    } else if (transport_type === "rif-comms") {
       register_body = {
         registration_data: {
           address,

--- a/test/store/actions/onboarding.test.js
+++ b/test/store/actions/onboarding.test.js
@@ -35,7 +35,7 @@ describe("test onboarding behaviour", () => {
     const store = mockStore(state);
     client.get.mockResolvedValue({
       data: {
-        transport_mode: "matrix",
+        transport_type: "matrix",
         display_name_to_sign: "name",
         seed_retry: "seed_retry",
         password_to_sign: "password",

--- a/test/store/actions/onboarding.test.js
+++ b/test/store/actions/onboarding.test.js
@@ -35,6 +35,7 @@ describe("test onboarding behaviour", () => {
     const store = mockStore(state);
     client.get.mockResolvedValue({
       data: {
+        transport_mode: "matrix",
         display_name_to_sign: "name",
         seed_retry: "seed_retry",
         password_to_sign: "password",


### PR DESCRIPTION
## Description 

This PR implements the onborading for rif comms. It must be merged with hhttps://github.com/rsksmart/lumino/pull/174

## Changelog

The onboarding is in two steps:

1. get hub data
2. register

- now we get the `transport_mode` from the hub data (step 1)
- according to that, we construct the registration body accordingly to each transport implementation

## Manually tested

- onboarding for new light client for matrix works
- same for rif comms
- onboarding for an already registered client works for both transports

